### PR TITLE
Implement the new receipt API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,6 @@ edition = "2018"
 path = "mmr/lib.rs"
 crate_type = ["rlib", "cdylib"]
 
-[[bin]]
-path = "shadow/mmr.rs"
-name = "mmr"
-
 [dependencies]
 uint = "0.8.3"
 blake2-rfc = "0.2.18"

--- a/api/api.go
+++ b/api/api.go
@@ -71,6 +71,7 @@ func Swagger(shadow *core.Shadow, port string) {
 
 	v1 := r.Group("/api/v1")
 	{
+		v1.GET("/batch/:block", c.BatchHeaders)
 		v1.GET("/header/:block", c.GetHeader)
 		v1.GET("/proof/:block", c.GetProof)
 		v1.GET("/receipt/:tx", c.GetReceipt)

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -268,8 +268,7 @@ var doc = `{
                     }
                 },
                 "receipt_proof": {
-                    "type": "object",
-                    "$ref": "#/definitions/eth.ProofRecord"
+                    "type": "string"
                 }
             }
         },
@@ -393,20 +392,6 @@ var doc = `{
                     "items": {
                         "type": "string"
                     }
-                }
-            }
-        },
-        "eth.ProofRecord": {
-            "type": "object",
-            "properties": {
-                "header_hash": {
-                    "type": "string"
-                },
-                "index": {
-                    "type": "string"
-                },
-                "proof": {
-                    "type": "string"
                 }
             }
         },

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -187,6 +187,13 @@ var doc = `{
                         "name": "tx",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "number",
+                        "description": "last confirm block",
+                        "name": "last",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -250,6 +257,10 @@ var doc = `{
         "core.GetReceiptResp": {
             "type": "object",
             "properties": {
+                "header": {
+                    "type": "object",
+                    "$ref": "#/definitions/eth.DarwiniaEthHeader"
+                },
                 "mmr_proof": {
                     "type": "array",
                     "items": {
@@ -259,6 +270,59 @@ var doc = `{
                 "receipt_proof": {
                     "type": "object",
                     "$ref": "#/definitions/eth.ProofRecord"
+                }
+            }
+        },
+        "eth.DarwiniaEthHeader": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "integer"
+                },
+                "extra_data": {
+                    "type": "string"
+                },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "gas_used": {
+                    "type": "integer"
+                },
+                "hash": {
+                    "type": "string"
+                },
+                "log_bloom": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "integer"
+                },
+                "parent_hash": {
+                    "type": "string"
+                },
+                "receipts_root": {
+                    "type": "string"
+                },
+                "seal": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "state_root": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "integer"
+                },
+                "transactions_root": {
+                    "type": "string"
+                },
+                "uncles_hash": {
+                    "type": "string"
                 }
             }
         },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -253,8 +253,7 @@
                     }
                 },
                 "receipt_proof": {
-                    "type": "object",
-                    "$ref": "#/definitions/eth.ProofRecord"
+                    "type": "string"
                 }
             }
         },
@@ -378,20 +377,6 @@
                     "items": {
                         "type": "string"
                     }
-                }
-            }
-        },
-        "eth.ProofRecord": {
-            "type": "object",
-            "properties": {
-                "header_hash": {
-                    "type": "string"
-                },
-                "index": {
-                    "type": "string"
-                },
-                "proof": {
-                    "type": "string"
                 }
             }
         },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -172,6 +172,13 @@
                         "name": "tx",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "number",
+                        "description": "last confirm block",
+                        "name": "last",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -235,6 +242,10 @@
         "core.GetReceiptResp": {
             "type": "object",
             "properties": {
+                "header": {
+                    "type": "object",
+                    "$ref": "#/definitions/eth.DarwiniaEthHeader"
+                },
                 "mmr_proof": {
                     "type": "array",
                     "items": {
@@ -244,6 +255,59 @@
                 "receipt_proof": {
                     "type": "object",
                     "$ref": "#/definitions/eth.ProofRecord"
+                }
+            }
+        },
+        "eth.DarwiniaEthHeader": {
+            "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "integer"
+                },
+                "extra_data": {
+                    "type": "string"
+                },
+                "gas_limit": {
+                    "type": "integer"
+                },
+                "gas_used": {
+                    "type": "integer"
+                },
+                "hash": {
+                    "type": "string"
+                },
+                "log_bloom": {
+                    "type": "string"
+                },
+                "number": {
+                    "type": "integer"
+                },
+                "parent_hash": {
+                    "type": "string"
+                },
+                "receipts_root": {
+                    "type": "string"
+                },
+                "seal": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "state_root": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "integer"
+                },
+                "transactions_root": {
+                    "type": "string"
+                },
+                "uncles_hash": {
+                    "type": "string"
                 }
             }
         },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -23,6 +23,9 @@ definitions:
     type: object
   core.GetReceiptResp:
     properties:
+      header:
+        $ref: '#/definitions/eth.DarwiniaEthHeader'
+        type: object
       mmr_proof:
         items:
           type: string
@@ -30,6 +33,41 @@ definitions:
       receipt_proof:
         $ref: '#/definitions/eth.ProofRecord'
         type: object
+    type: object
+  eth.DarwiniaEthHeader:
+    properties:
+      author:
+        type: string
+      difficulty:
+        type: integer
+      extra_data:
+        type: string
+      gas_limit:
+        type: integer
+      gas_used:
+        type: integer
+      hash:
+        type: string
+      log_bloom:
+        type: string
+      number:
+        type: integer
+      parent_hash:
+        type: string
+      receipts_root:
+        type: string
+      seal:
+        items:
+          type: string
+        type: array
+      state_root:
+        type: string
+      timestamp:
+        type: integer
+      transactions_root:
+        type: string
+      uncles_hash:
+        type: string
     type: object
   eth.DarwiniaEthHeaderHexFormat:
     properties:
@@ -238,6 +276,11 @@ paths:
         name: tx
         required: true
         type: string
+      - description: last confirm block
+        in: query
+        name: last
+        required: true
+        type: number
       produces:
       - application/json
       responses:

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -31,8 +31,7 @@ definitions:
           type: string
         type: array
       receipt_proof:
-        $ref: '#/definitions/eth.ProofRecord'
-        type: object
+        type: string
     type: object
   eth.DarwiniaEthHeader:
     properties:
@@ -114,15 +113,6 @@ definitions:
         items:
           type: string
         type: array
-    type: object
-  eth.ProofRecord:
-    properties:
-      header_hash:
-        type: string
-      index:
-        type: string
-      proof:
-        type: string
     type: object
   types.Header:
     properties:

--- a/api/http.go
+++ b/api/http.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/darwinia-network/shadow/internal/core"
 	"github.com/darwinia-network/shadow/internal/ffi"
@@ -103,6 +105,7 @@ func (c *ShadowHTTP) GetProof(ctx *gin.Context) {
 // @Accept  json
 // @Produce  json
 // @Param tx path string true "tx hash"
+// @Param last query number true "last confirm block"
 // @Success 200 {array} core.GetReceiptResp
 // @Header 200 {string} Token "qwerty"
 // @Failure 400 {object} HTTPError
@@ -114,6 +117,14 @@ func (c *ShadowHTTP) GetReceipt(ctx *gin.Context) {
 		return
 	}
 
+	last := ctx.DefaultQuery("last", "0")
+	lastLeaf, err := strconv.ParseUint(last, 10, 64)
+	if err != nil {
+		NewError(ctx, http.StatusBadRequest, err)
+		return
+	}
+
+	receipt.MMRProof = strings.Split(ffi.ProofLeaves(lastLeaf, receipt.Header.Number), ",")
 	ctx.JSON(http.StatusOK, receipt)
 }
 

--- a/api/http.go
+++ b/api/http.go
@@ -118,13 +118,13 @@ func (c *ShadowHTTP) GetReceipt(ctx *gin.Context) {
 	}
 
 	last := ctx.DefaultQuery("last", "0")
-	lastLeaf, err := strconv.ParseUint(last, 10, 64)
+	member, err := strconv.ParseUint(last, 10, 64)
 	if err != nil {
 		NewError(ctx, http.StatusBadRequest, err)
 		return
 	}
 
-	receipt.MMRProof = strings.Split(ffi.ProofLeaves(lastLeaf, receipt.Header.Number), ",")
+	receipt.MMRProof = strings.Split(ffi.ProofLeaves(receipt.Header.Number, member), ",")
 	ctx.JSON(http.StatusOK, receipt)
 }
 

--- a/internal/core/cache.go
+++ b/internal/core/cache.go
@@ -27,9 +27,8 @@ type EthHeaderWithProofCache struct {
 	Header string `json:"eth_header"`
 	Proof  string `json:"proof"`
 	// MMR
-	Pos      string `json:"pos"`
-	Root     string `json:"root" gorm:"DEFAULT:NULL"`
-	MMRProof string `json:"mmr_proof" gorm:"DEFAULT:NULL"`
+	Pos  string `json:"pos"`
+	Root string `json:"root" gorm:"DEFAULT:NULL"`
 }
 
 func (c *EthHeaderWithProofCache) Parse(block interface{}) error {

--- a/internal/core/cache.go
+++ b/internal/core/cache.go
@@ -172,7 +172,7 @@ func (c *EthHeaderWithProofCache) Fetch(
 		block interface{}
 	)
 
-	if !util.IsEmpty(c.Number) && c.Number != 0 {
+	if !util.IsEmpty(c.Number) || c.Number == 0 {
 		block = c.Number
 		err = db.Where("number = ?", c.Number).Take(&c).Error
 	} else if !util.IsEmpty(c.Hash) {

--- a/internal/core/shadow.go
+++ b/internal/core/shadow.go
@@ -57,6 +57,8 @@ func (s *Shadow) checkGenesis(genesis uint64, block interface{}) (uint64, error)
 		return b, nil
 	case string:
 		eH, err := eth.Header(b, s.Config.Api)
+		log.Trace("%v", b)
+		log.Trace("%v", eH)
 		if err != nil {
 			return genesis, err
 		}
@@ -73,7 +75,8 @@ func (s *Shadow) checkGenesis(genesis uint64, block interface{}) (uint64, error)
 		}
 
 		// Check genesis by number
-		if dH.Number <= genesis {
+		if dH.Number < genesis {
+			log.Error("Requesting block %v", dH.Number)
 			return genesis, fmt.Errorf(GENESIS_ERROR, genesis)
 		}
 

--- a/internal/core/shadow.go
+++ b/internal/core/shadow.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/darwinia-network/shadow/internal"
 	"github.com/darwinia-network/shadow/internal/eth"
@@ -209,6 +208,7 @@ func (s *Shadow) GetReceipt(
 		return
 	}
 
-	resp.MMRProof = strings.Split(cache.MMRProof, ",")
+	cr, err := cache.IntoResp()
+	resp.Header = cr.Header
 	return
 }

--- a/internal/core/shadow.go
+++ b/internal/core/shadow.go
@@ -201,7 +201,7 @@ func (s *Shadow) GetReceipt(
 		return
 	}
 
-	resp.ReceiptProof = proof
+	resp.ReceiptProof = proof.Proof
 	cache := EthHeaderWithProofCache{Hash: hash}
 	err = cache.Fetch(s.Config, s.DB)
 	if err != nil {

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -129,6 +129,7 @@ type ProposalResp struct {
 
 // Receipt
 type GetReceiptResp struct {
-	ReceiptProof eth.ProofRecord `json:"receipt_proof"`
-	MMRProof     []string        `json:"mmr_proof"`
+	ReceiptProof eth.ProofRecord       `json:"receipt_proof"`
+	Header       eth.DarwiniaEthHeader `json:"header"`
+	MMRProof     []string              `json:"mmr_proof"`
 }

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -129,7 +129,7 @@ type ProposalResp struct {
 
 // Receipt
 type GetReceiptResp struct {
-	ReceiptProof eth.ProofRecord       `json:"receipt_proof"`
+	ReceiptProof string                `json:"receipt_proof"`
 	Header       eth.DarwiniaEthHeader `json:"header"`
 	MMRProof     []string              `json:"mmr_proof"`
 }

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -129,7 +129,7 @@ type ProposalResp struct {
 
 // Receipt
 type GetReceiptResp struct {
-	ReceiptProof string                `json:"receipt_proof"`
 	Header       eth.DarwiniaEthHeader `json:"header"`
+	ReceiptProof string                `json:"receipt_proof"`
 	MMRProof     []string              `json:"mmr_proof"`
 }

--- a/internal/tests/shadow_test.go
+++ b/internal/tests/shadow_test.go
@@ -111,7 +111,7 @@ func TestGetReceipt(t *testing.T) {
 		shadow, err := core.NewShadow()
 		util.Assert(err)
 
-		resp, err := shadow.GetReceipt("0x33d48b9108b72d4bfa238124717e0b36cbaf404b01b158013901e86f7368912d")
+		resp, err := shadow.GetReceipt("/0x663cffc56aece411d9dc8096a162b65089d720d69e06f953bd58804cedebb06f")
 		util.Assert(err)
 
 		util.AssertEmpty(resp.Header)

--- a/internal/tests/shadow_test.go
+++ b/internal/tests/shadow_test.go
@@ -105,3 +105,16 @@ func TestBatchEthHeaderWithProofByNumber(t *testing.T) {
 		}
 	})
 }
+
+func TestGetReceipt(t *testing.T) {
+	t.Run("Test GetReceipt", func(t *testing.T) {
+		shadow, err := core.NewShadow()
+		util.Assert(err)
+
+		resp, err := shadow.GetReceipt("0x33d48b9108b72d4bfa238124717e0b36cbaf404b01b158013901e86f7368912d")
+		util.Assert(err)
+
+		util.AssertEmpty(resp.Header)
+		util.AssertEmpty(resp.ReceiptProof)
+	})
+}

--- a/internal/util/assert.go
+++ b/internal/util/assert.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"os"
 	"reflect"
 
 	"github.com/darwinia-network/shadow/internal/log"
@@ -16,6 +17,8 @@ func Assert(err error) {
 	if err != nil {
 		log.Error("%v", err)
 	}
+
+	os.Exit(1)
 }
 
 // Assert error and exit process

--- a/internal/util/assert.go
+++ b/internal/util/assert.go
@@ -16,9 +16,8 @@ func IsEmpty(x interface{}) bool {
 func Assert(err error) {
 	if err != nil {
 		log.Error("%v", err)
+		os.Exit(1)
 	}
-
-	os.Exit(1)
 }
 
 // Assert error and exit process

--- a/shadow/mmr.rs
+++ b/shadow/mmr.rs
@@ -1,4 +1,0 @@
-fn main() {
-    let mut runner = mmr::Runner::default();
-    runner.start().unwrap();
-}


### PR DESCRIPTION
## Desc

|Requst| Resp|
|-|-|
| `/receipt/:tx?last={number}`|{"header": `DarwiniaEthHeader`, "receipt_proof": `string`, "mmr_proof": `[]string` }|

+ [x] Update the mmr_proof field
+ [x] ~~Change the `proof` field to `receipt_proof`~~

## Note

The `mmr_proof` field is hard to test because the local storage doesn't have enough blocks to generate `mmr_root`s

## Preview

<details>
<summary>
The receipt response of tx <code>0x663cffc56aece411d9dc8096a162b65089d720d69e06f953bd58804cedebb06f</code>(mainnet)
</summary>
<pre><code>
{
  "header": {
    "parent_hash": "0xd00ff2c9391762f331dff32fd30bdb1ec5c4ed57bd3fc3b6990bca32e16de223",
    "timestamp": 1594850649,
    "number": 10466662,
    "author": "0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c",
    "transactions_root": "0x3957eee99db1329a7ebfb663f24174d7e0930049ea5d771e7c16849bcfc5dba8",
    "uncles_hash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "extra_data": "0x737061726b706f6f6c2d6574682d7477",
    "state_root": "0xc71c94c065bf3cbf143be2bcacc494ce6495fa518be1883fff778effe6de4174",
    "receipts_root": "0x8c820d2db59fd7ec216efa7632e8f53e0f7a10864545af3b5e2c59ed28c33124",
    "log_bloom": "0xc4321043858025a980849292860494a900800a21871853541111001a81c7000300800b002008390a111400003400094003434680898b922b68165054987020201b1030600522c483ec080108a09600a11200040220da0141320d5020a412908e141c0100264104e04e000120230dac00484013102450540508394790900030008a130300a0016080804808f1504104180034348d71e4e4aa04c42148029001828b2b00080a8025888880998180119a0200412104a0240801019414229842c8210c0845262c181340481014840418010e040003604011d070c00a082a012420805030ea11433054302181840a9080880000a0821224d022421000008c48010008",
    "gas_used": 11982720,
    "gas_limit": 11994078,
    "difficulty": 2383313513113179,
    "seal": [
      "0xa05eadfe07ef69436e0f5d31d5e8b6108536206a0249ad3c89212621afbc6cf594",
      "0x881b03d33c9242f19b"
    ],
    "hash": "0x13b6ca8968bf0a539092224f35c70609d69481e5cbaa4524d930f2e93f9f8222"
  },
  "receipt_proof": "0xf905bef905bbb8f3f8f1a01c299a640a3dfe984c5aec3c2d2a1cc15fed5886e1f62a130c4cc77c0bc2ee79a071de73233b3c41ca7aa0879242e17e82fb6c5ea58587a36fd2d8afe57ca6066ca075d2de6c9531762bec8b3e98792fbb355185aaa73a5f2875eb724c355ebaadf5a0eef877108ed8790b3f1408cdbb1388266b52df6751b73ebc114dc7af3172347ea03bd7b1d794340c0d0808ae0689ddaaa1836369ed8124bc6dad9073367e5e4829a0fa0abb3efc9d7e03fd49413d0be2f9e7981accc44447381303fb8e66b5edcadf8080a06e5c5bb19121e7632f4841c723627515162b75c12d635ab18a3f614ef86247908080808080808080b90214f90211a00b7f473c9e210fbc298efd234cf136f3d812835c330b9fb85033866ab6ce7070a0aac841f1261fb814f7f902b5a14ad990afd04f6a0310a0d1898c713c03f461f3a09dcb0ce273582074288bb113e99defe14551c65b241e7066855d7ffd5f315087a0b264aeadd2e0303ef4f8adfbf9839705aafc24f8a37522180535c5480d19a599a027fde691e143ac7157986a9ba0294b7562fa2348ae97a029d639bffdd75a6932a0da0b8cdfb7badf4f1f8958ddf8219f480a34a778641558d799be9c1f9303cf7aa0239a8a8be0af244c02f4aa201dc475c1f5e862593af6b18767edbc241f2038d5a0004d8c4ab4c292bdca2ae6793605118bfcb99ad7bfcd7522acd57fdebd750563a02edfdebfe8138c1180b7b14ecfe71454bdd3ab3ae1ee7bf8d96429bc11801e7ba0fcda5774b744d03a8817d39b4cd251ae9ff4381c34613e0b4cdbd38318234831a0affa803f47ca0231e9ff28720bb9862212503f5914b3f2f5ee4d5c3e3e4c483ca0976dc595c3831fbbb04cdd2a88d7c50601cf1dcac9cc6dffb19e3afc06faed90a0313fefb92bc3c88fadb382fae4d03c6b7da6f66f7e1363640a71966473d0c71ba0ac7ae43133bf50a571088df56b2c99edeeb482294b8824b0a5bfc2b6371deabaa050942e4643c8c749a5252ecb8ad1a4f9f77185b38373fac4429721a24336b5cca0ded38795840fe38b41f7898abe1ee667b04da203cf899acc48a7f9f3a7225b3080b902acf902a920b902a5f902a20183288e0ab9010000000000040000010000009000000000000008200000000000000000008000000000000000000000001000000000000000000000000200000000000000000000100000000000000000000000000000000000040000000000000000000000000000000000200100000000000000000000400000000400000000000000100000008001000000000000000000000000000000000480000000000000000000000000000000000800010000000000000000000000000000000000010000000000000000000000000002000000000000000008000000000000000000000000000000000000080000000000000000000000000000000000040000000000000000000000f90197f89c94628ac7c9742a52931486b9af6e54db4511fefe42f884a092e98423f8adac6e64d0608e519fd1cefb861498385c6dee70d58fc926ddc68ca000000000000000000000000000000000000000000000000000000000000e57e0a0000000000000000000000000000000000000000000000000000000000000018ea00000000000000000000000000699a397c3cf614c9a7db23a4be28fc4c8f3a75580f89b94628ac7c9742a52931486b9af6e54db4511fefe42f863a00559884fd3a460db3073b7fc896cc77986f16e378210ded43186175bf646fc5fa000000000000000000000000000000000000000000000000000000000000e4426a0000000000000000000000000000000000000000000000000000000000000018ea0000000000000000000000000000000000000000000000000000000005f0f7d59f85a94628ac7c9742a52931486b9af6e54db4511fefe42f842a0fe25c73e3b9089fac37d55c4c7efcba6f04af04cebd2fc4d6d7dbb07e1e5234fa00000000000000000000000000000000000000000000000638066e735cdfc000080",
  "mmr_proof": [""]
}
</code></pre></details>

## How to test?

```
$ ./target/shadow run -v
curl "http://localhost:3001/api/v1/receipt/0x33d48b9108b72d4bfa238124717e0b36cbaf404b01b158013901e86f7368912d?last=0"
```