### PR TITLE
Implements export command for data migration

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/darwinia-network/shadow/internal/core"
@@ -51,6 +52,13 @@ var cmdExport = &cobra.Command{
 			headers = append(headers, raw.Header.Ser())
 		}
 
-		fmt.Println(strings.Join(headers, ","))
+		err = ioutil.WriteFile(
+			fmt.Sprintf("%s/%s", PATH, NAME),
+			[]byte(strings.Join(headers, ",")),
+			0644,
+		)
+		util.Assert(err)
+
+		fmt.Printf("Exported %v blocks!\n", len(headers))
 	},
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,31 +1,58 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-	"github.com/spf13/cobra"
+	"io/ioutil"
 
 	"github.com/darwinia-network/shadow/internal/core"
+	"github.com/darwinia-network/shadow/internal/util"
+	"github.com/spf13/cobra"
 )
 
-// func init() {
-// 	cmdExport.PersistentFlags().StringVarP(
-// 		&PATH,
-// 		"path",
-// 		"p",
-// 		".",
-// 		"The export path",
-// 	)
-// }
+func init() {
+	cmdExport.PersistentFlags().StringVarP(
+		&PATH,
+		"path",
+		"p",
+		".",
+		"The export path",
+	)
+
+	cmdExport.PersistentFlags().StringVarP(
+		&NAME,
+		"name",
+		"n",
+		"shadow.blocks",
+		"The database export name",
+	)
+}
+
+type Blocks struct {
+	Blocks []core.EthHeaderWithProofCache
+}
 
 var cmdExport = &cobra.Command{
-	Use:   "export [path]",
+	Use:   "export",
 	Short: "Export Shadow Database",
 	Long:  "Export shadow database to path",
 	Args:  cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		shadow, _ := core.NewShadow()
+		shadow, err := core.NewShadow()
+		util.Assert(err)
+
 		var blocks []core.EthHeaderWithProofCache
 		shadow.DB.Find(&blocks)
-		fmt.Println(blocks)
+
+		for _, b := range blocks {
+			b.Proof = ""
+		}
+
+		// Convert blocks to header
+		bytes, err := json.Marshal(blocks)
+		util.Assert(err)
+
+		err = ioutil.WriteFile(fmt.Sprintf("%s/%s", PATH, NAME), bytes, 0644)
+		util.Assert(err)
 	},
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+
+	"github.com/darwinia-network/shadow/internal/core"
+)
+
+// func init() {
+// 	cmdExport.PersistentFlags().StringVarP(
+// 		&PATH,
+// 		"path",
+// 		"p",
+// 		".",
+// 		"The export path",
+// 	)
+// }
+
+var cmdExport = &cobra.Command{
+	Use:   "export [path]",
+	Short: "Export Shadow Database",
+	Long:  "Export shadow database to path",
+	Args:  cobra.MinimumNArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		shadow, _ := core.NewShadow()
+		var blocks []core.EthHeaderWithProofCache
+		shadow.DB.Find(&blocks)
+		fmt.Println(blocks)
+	},
+}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,9 +1,8 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"strings"
 
 	"github.com/darwinia-network/shadow/internal/core"
 	"github.com/darwinia-network/shadow/internal/util"
@@ -44,15 +43,14 @@ var cmdExport = &cobra.Command{
 		var blocks []core.EthHeaderWithProofCache
 		shadow.DB.Find(&blocks)
 
+		var headers []string
 		for _, b := range blocks {
-			b.Proof = ""
+			raw, err := b.IntoResp()
+			util.Assert(err)
+
+			headers = append(headers, raw.Header.Ser())
 		}
 
-		// Convert blocks to header
-		bytes, err := json.Marshal(blocks)
-		util.Assert(err)
-
-		err = ioutil.WriteFile(fmt.Sprintf("%s/%s", PATH, NAME), bytes, 0644)
-		util.Assert(err)
+		fmt.Println(strings.Join(headers, ","))
 	},
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/darwinia-network/shadow/internal/core"
+	"github.com/darwinia-network/shadow/internal/eth"
+	"github.com/darwinia-network/shadow/internal/util"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmdImport.PersistentFlags().StringVarP(
+		&PATH,
+		"path",
+		"p",
+		".",
+		"The export path",
+	)
+
+	cmdImport.PersistentFlags().StringVarP(
+		&NAME,
+		"name",
+		"n",
+		"shadow.blocks",
+		"The database export name",
+	)
+}
+
+var cmdImport = &cobra.Command{
+	Use:   "import",
+	Short: "Import Shadow blocks",
+	Long:  "Import Shadow blocks from file",
+	Args:  cobra.MinimumNArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		shadow, err := core.NewShadow()
+		util.Assert(err)
+
+		hb, err := ioutil.ReadFile(
+			fmt.Sprintf("%s/%s", PATH, NAME),
+		)
+		util.Assert(err)
+
+		headers := strings.Split(string(hb), ",")
+
+		var blocks []core.EthHeaderWithProofCache
+		for _, h := range headers {
+			dh := eth.DarwiniaEthHeader{}
+			err = dh.De(h)
+
+			header, err := json.Marshal(dh)
+			util.Assert(err)
+
+			blocks = append(blocks, core.EthHeaderWithProofCache{
+				Number: dh.Number,
+				Hash:   dh.Hash,
+				Header: string(header),
+			})
+			util.Assert(err)
+		}
+
+		for _, b := range blocks {
+			if shadow.DB.Model(&b).Where(
+				"number = ?", b.Number,
+			).Updates(&b).RowsAffected == 0 {
+				shadow.DB.Create(&b)
+			}
+		}
+
+		fmt.Printf("Imported %v blocks!\n", len(blocks))
+	},
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -50,6 +50,7 @@ var cmdImport = &cobra.Command{
 		for _, h := range headers {
 			dh := eth.DarwiniaEthHeader{}
 			err = dh.De(h)
+			util.Assert(err)
 
 			header, err := json.Marshal(dh)
 			util.Assert(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ var (
 	HTTP         string
 	PROOF_FORMAT string
 	PATH         string
+	NAME         string
 )
 
 const (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ var (
 	VERBOSE      bool
 	HTTP         string
 	PROOF_FORMAT string
+	PATH         string
 )
 
 const (
@@ -34,6 +35,7 @@ func init() {
 		cmdRun,
 		cmdVersion,
 		cmdTest,
+		cmdExport,
 	)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ func init() {
 		cmdVersion,
 		cmdTest,
 		cmdExport,
+		cmdImport,
 	)
 }
 

--- a/internal/core/shadow.go
+++ b/internal/core/shadow.go
@@ -39,9 +39,7 @@ func NewShadow() (Shadow, error) {
 	}, err
 }
 
-/**
- * Genesis block checker
- */
+// Genesis block checker
 func (s *Shadow) checkGenesis(genesis uint64, block interface{}) (uint64, error) {
 	block, err := util.NumberOrString(block)
 	if err != nil {

--- a/internal/eth/serde.go
+++ b/internal/eth/serde.go
@@ -1,0 +1,86 @@
+package eth
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func (h *DarwiniaEthHeader) Ser() string {
+	return fmt.Sprintf(
+		"%s|%v|%v|%s|%s|%s|%s|%s|%s|%s|%v|%v|%v|%s|%s",
+		h.ParentHash,
+		h.TimeStamp,
+		h.Number,
+		h.Author,
+		h.TransactionsRoot,
+		h.UnclesHash,
+		h.ExtraData,
+		h.StateRoot,
+		h.ReceiptsRoot,
+		h.LogBloom,
+		h.GasUsed,
+		h.GasLimited,
+		h.Difficulty,
+		fmt.Sprintf("%s.%s", h.Seal[0], h.Seal[1]),
+		h.Hash,
+	)
+}
+
+func (h *DarwiniaEthHeader) De(str string) error {
+	sa := strings.Split(str, "|")
+	if len(sa) != 15 {
+		return fmt.Errorf(
+			"Deserialize DarwiniaEthHeader failed, the lenght is %v, expect 15",
+			len(sa),
+		)
+	}
+
+	// timestamp
+	ts, err := strconv.ParseUint(sa[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("Parse timestamp failed: %v", sa[1])
+	}
+
+	// number
+	num, err := strconv.ParseUint(sa[2], 10, 64)
+	if err != nil {
+		return fmt.Errorf("Parse block number failed: %v", sa[2])
+	}
+
+	// gas used
+	gasUsed, err := strconv.ParseUint(sa[10], 10, 64)
+	if err != nil {
+		return fmt.Errorf("Parse block gas used failed: %v", sa[10])
+	}
+
+	// gas limited
+	gasLimited, err := strconv.ParseUint(sa[11], 10, 64)
+	if err != nil {
+		return fmt.Errorf("Parse block gas limited failed: %v", sa[11])
+	}
+
+	// difficulty
+	diff, err := strconv.ParseUint(sa[12], 10, 64)
+	if err != nil {
+		return fmt.Errorf("Parse block gas used failed: %v", sa[12])
+	}
+
+	h.ParentHash = sa[0]
+	h.TimeStamp = ts
+	h.Number = num
+	h.Author = sa[3]
+	h.TransactionsRoot = sa[4]
+	h.UnclesHash = sa[5]
+	h.ExtraData = sa[6]
+	h.StateRoot = sa[7]
+	h.ReceiptsRoot = sa[8]
+	h.LogBloom = sa[9]
+	h.GasUsed = gasUsed
+	h.GasUsed = gasLimited
+	h.Difficulty = diff
+	h.Seal = strings.Split(sa[13], ".")
+	h.Hash = sa[14]
+
+	return nil
+}


### PR DESCRIPTION
## Usage

```shell
# export
𝝺 shadow export --help
Export shadow database to path

Usage:
  shadow export [flags]

Flags:
  -h, --help          help for export
  -n, --name string   The database export name (default "shadow.blocks")
  -p, --path string   The export path (default ".")

# import
 𝝺 shadow import --help
Import Shadow blocks from path

Usage:
  shadow import [flags]

Flags:
  -h, --help          help for import
  -n, --name string   The database export name (default "shadow.blocks")
  -p, --path string   The export path (default ".")
```

Exports database to specifical path

## Steps

+ [x] Init export command
+ [x] optimize data format
+ [x] add import command