### PR TITLE
Use rust-1.45.2 in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Shadow in a stock rust builder container
-FROM rust:alpine as shadow
+FROM rust:1.45.2-alpine as shadow
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Los_Angeles
 COPY . shadow


### PR DESCRIPTION
## Desc

The latest `rust:alpine` has `Segmentation fault (core dumped)` BUG because it links the `libc.musl-x86_64.so.1` for twice time.