### PR TITLE
Fix the data source of Ethereum receipt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darwinia-shadow"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["clearloop <udtrokia@gmail.com>"]
 edition = "2018"
 description = "The shadow service for relayers and verify workers to retrieve header data and generate proof."

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The shadow service for relayers and verify workers to retrieve header data and g
 ## Usage
 
 ```sh
-shadow 0.2.0
+shadow 0.2.2
 
 USAGE:
     shadow <SUBCOMMAND>
@@ -43,10 +43,11 @@ $ cargo install darwinia-shadow
 
 ## Environment
 
-| ENV            | Desc                     | Example                            |
-|----------------|--------------------------|------------------------------------|
-| `ETHEREUM_RPC` | The rpc of ethereum node | ETHEREUM_RPC=http://localhost:8545 |
-| `MMR_LOG`      | The gap of mmr logs      | MMR_LOG=10000                      |
+| ENV                | Desc                     | Example                            |
+|--------------------|--------------------------|------------------------------------|
+| `ETHEREUM_RPC`     | The rpc of ethereum node | ETHEREUM_RPC=http://localhost:8545 |
+| `ETHEREUM_ROPSTEN` | Enable ropsten source    | ETHEREUM_ROPSTEN=true              |
+| `MMR_LOG`          | The gap of mmr logs      | MMR_LOG=10000                      |
 
 ## Trouble Shooting
 

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,8 @@ use std::{env, process::Command};
 fn main() {
     // Pre-check
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=pkg/shadow/eth/receipt.go");
+    println!("cargo:rerun-if-changed=pkg/shadow/eth/proof.go");
     println!("cargo:rerun-if-changed=pkg/shadow/ffi/mod.go");
 
     // Declare build args

--- a/pkg/shadow/config.go
+++ b/pkg/shadow/config.go
@@ -14,6 +14,7 @@ const (
 	SHADOW_GENESIS       string = "SHADOW_GENESIS"
 	GETH_DATADIR         string = "GETH_DATADIR"
 	DEFAULT_ETHEREUM_RPC string = "https://mainnet.infura.io/v3/0bfb9acbb13c426097aabb1d81a9d016"
+	DEFAULT_ROPSTEN_RPC  string = "https://ropsten.infura.io/v3/0bfb9acbb13c426097aabb1d81a9d016"
 )
 
 type RawConfig struct {
@@ -49,8 +50,12 @@ func (c *Config) Load() error {
 
 	// Load api from env
 	c.Api = os.Getenv(ETHEREUM_RPC)
-	if c.Api == "" && os.Getenv(ETHEREUM_ROPSTEN) == "" {
-		c.Api = DEFAULT_ETHEREUM_RPC
+	if c.Api == "" {
+		if os.Getenv(ETHEREUM_ROPSTEN) == "" {
+			c.Api = DEFAULT_ETHEREUM_RPC
+		} else {
+			c.Api = DEFAULT_ROPSTEN_RPC
+		}
 	}
 
 	return nil

--- a/pkg/shadow/eth/receipt.go
+++ b/pkg/shadow/eth/receipt.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"errors"
 	"math"
+	"os"
 	"strings"
 	"sync"
 
 	"github.com/darwinia-network/shadow/pkg/shadow"
+	"github.com/darwinia-network/shadow/pkg/shadow/log"
 	"github.com/darwinia-network/shadow/pkg/shadow/util"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -30,7 +32,15 @@ var (
 func init() {
 	conf := new(shadow.Config)
 	_ = conf.Load()
-	API = conf.Api
+	if strings.Contains(conf.Api, "infura") {
+		API = conf.Api
+	} else {
+		if os.Getenv(shadow.ETHEREUM_ROPSTEN) == "" {
+			API = shadow.DEFAULT_ETHEREUM_RPC
+		} else {
+			API = shadow.DEFAULT_ROPSTEN_RPC
+		}
+	}
 }
 
 func GetChainBlockInfo(blockNum int64) (*BlockResult, error) {
@@ -118,6 +128,7 @@ type RedeemFor struct {
 func GetReceipt(tx string) (ProofRecord, string, error) {
 	r, err := GetReceiptLog(tx)
 	if err != nil || r == nil {
+		log.Error("%s", err)
 		return ProofRecord{}, "", err
 	}
 

--- a/src/chain/eth/header.rs
+++ b/src/chain/eth/header.rs
@@ -24,7 +24,7 @@ impl EthHeaderRPCResp {
         let map: Value = serde_json::from_str(&format! {
             "{{{}}}", vec![
                 r#""jsonrpc":"2.0","#,
-                r#""method":"eth_getBlockByNumber","#,
+                r#""method":"eth_getBlockByHash","#,
                 &format!(r#""params":["{}", false],"#, block),
                 r#""id": 1"#,
             ].concat(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,17 @@
 //! # Shadow
 //!
 //! [![Shadow][workflow-badge]][github]
-//! [![crate](https://img.shields.io/crates/v/darwinia-shadow.svg)](https://crates.io/crates/elvis)
+//! [![crate](https://img.shields.io/crates/v/darwinia-shadow.svg)](https://crates.io/crates/darwinia_shadow)
 //! [![doc](https://img.shields.io/badge/current-docs-brightgreen.svg)](https://docs.rs/darwinia_shadow/)
 //! [![LICENSE](https://img.shields.io/crates/l/darwinia-shadow.svg)](https://choosealicense.com/licenses/gpl-3.0/)
 //!
 //! The shadow service for relayers and verify workers to retrieve header data and generate proof. Shadow will index the data it needs from blockchain nodes, such as Ethereum and Darwinia.
 //!
+//!
 //! ## Usage
 //!
 //! ```sh
-//! shadow 0.2.0
+//! shadow 0.2.2
 //!
 //! USAGE:
 //!     shadow <SUBCOMMAND>
@@ -26,21 +27,33 @@
 //!     trim     Trim mmr from target leaf
 //! ```
 //!
+//!
 //! ## Download
 //!
 //! ```sh
 //! $ cargo install darwinia-shadow
 //! ```
 //!
+//!
 //! ### Note
 //!
 //! + Please make sure you have `golang` installed in your machine
 //! + Please make sure you have `sqlite3` installed in your machine
 //!
+//!
+//! ## Environment
+//!
+//! | ENV                | Desc                     | Example                            |
+//! |--------------------|--------------------------|------------------------------------|
+//! | `ETHEREUM_RPC`     | The rpc of ethereum node | ETHEREUM_RPC=http://localhost:8545 |
+//! | `ETHEREUM_ROPSTEN` | Enable ropsten source    | ETHEREUM_ROPSTEN=true              |
+//! | `MMR_LOG`          | The gap of mmr logs      | MMR_LOG=10000                      |
+//!
 //! ## Trouble Shooting
 //!
 //! Everytime you run `proof` in error, please delete `~/.ethashproof` and `~/.ethash`
 //! and retry.
+//!
 //!
 //! ## LICENSE
 //!
@@ -49,6 +62,7 @@
 //!
 //! [github]: https://github.com/darwinia-network/shadow
 //! [workflow-badge]: https://github.com/darwinia-network/shadow/workflows/shadow/badge.svg
+
 #![warn(missing_docs)]
 #![allow(clippy::transmute_ptr_to_ptr)]
 #![allow(clippy::ptr_offset_with_cast)]


### PR DESCRIPTION
## Desc

The data source of ethereum receipt proof will force using Infura API in this version.