### PR TITLE
Update the receipt API

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,33 @@
+name: Staging
+on:
+  push:
+    branches: ["staging"]
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: itering/actions
+          path: .github/actions
+          persist-credentials: false
+          ssh-key: "${{ secrets.ITERING_ACTIONS_DEPLOY_KEY }}"
+
+      - uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.QUAY_IO_BOT_USERNAME }}
+          password: ${{ secrets.QUAY_IO_BOT_PASSWORD }}
+          registry: quay.io
+          repository: ${{ github.repository }}
+          add_git_labels: true
+          tag_with_sha: true
+          tag_with_ref: false
+
+      - uses: ./.github/actions/trigger-deployment
+        with:
+          deploy_phase: staging
+          trigger_token: ${{ secrets.ITERING_DEPLOYMENT_TRIGGER_TOKEN }}
+          trigger_endpoint: ${{ secrets.ITERING_DEPLOYMENT_TRIGGER_ENDPOINT }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darwinia-shadow"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["clearloop <udtrokia@gmail.com>"]
 edition = "2018"
 description = "The shadow service for relayers and verify workers to retrieve header data and generate proof."

--- a/src/.#lib.rs
+++ b/src/.#lib.rs
@@ -1,1 +1,0 @@
-d@MacBook-Pro.nkg.itering.com.4602

--- a/src/.#lib.rs
+++ b/src/.#lib.rs
@@ -1,0 +1,1 @@
+d@MacBook-Pro.nkg.itering.com.4602

--- a/src/api/eth/proposal.rs
+++ b/src/api/eth/proposal.rs
@@ -17,7 +17,7 @@ pub struct ProposalReq {
     /// The target proposal block
     pub target: u64,
     /// The last leaf of mmr
-    pub leaf: u64,
+    pub last_leaf: u64,
 }
 
 impl ProposalReq {
@@ -60,11 +60,11 @@ impl ProposalReq {
 
     /// Generate mmr proof
     pub fn mmr_proof(&self, store: &Store) -> Vec<String> {
-        if self.leaf < 1 {
+        if self.last_leaf < 1 {
             return vec![];
         }
 
-        helper::gen_proof(store, self.member, self.leaf)
+        helper::gen_proof(store, self.member, self.last_leaf)
     }
 
     /// Generate response
@@ -97,7 +97,7 @@ pub struct ProposalHeader {
 /// eth::proposal(web::Json(eth::ProposalReq{
 ///     member: 10,
 ///     target: 19,
-///     leaf: 18
+///     last_leaf: 18
 /// }), web::Data::new(ShadowShared::new(None)));
 /// ```
 pub async fn handle(req: web::Json<ProposalReq>, share: web::Data<ShadowShared>) -> impl Responder {

--- a/src/api/eth/proposal.rs
+++ b/src/api/eth/proposal.rs
@@ -13,11 +13,11 @@ use scale::{Decode, Encode};
 #[derive(Deserialize, Encode)]
 pub struct ProposalReq {
     /// MMR leaves
-    pub leaves: Vec<u64>,
+    pub member: u64,
     /// The target proposal block
     pub target: u64,
     /// The last leaf of mmr
-    pub last_leaf: u64,
+    pub leaf: u64,
 }
 
 impl ProposalReq {
@@ -60,14 +60,14 @@ impl ProposalReq {
 
     /// Generate mmr proof
     pub fn mmr_proof(&self, store: &Store) -> Vec<String> {
-        if self.last_leaf < 1 || self.leaves.is_empty() {
+        if self.leaf < 1 {
             return vec![];
         }
 
-        helper::gen_proof(store, &self.leaves, self.last_leaf)
+        helper::gen_proof(store, self.member, self.leaf)
     }
 
-    /// To headers
+    /// Generate response
     pub async fn gen(&self, shared: web::Data<ShadowShared>) -> ProposalHeader {
         ProposalHeader {
             header: self.header(&shared.client).await,
@@ -95,9 +95,9 @@ pub struct ProposalHeader {
 ///
 /// // POST `/eth/proposal`
 /// eth::proposal(web::Json(eth::ProposalReq{
-///     leaves: vec![10],
+///     member: 10,
 ///     target: 19,
-///     last_leaf: 18
+///     leaf: 18
 /// }), web::Data::new(ShadowShared::new(None)));
 /// ```
 pub async fn handle(req: web::Json<ProposalReq>, share: web::Data<ShadowShared>) -> impl Responder {

--- a/src/chain/eth/mmr_proof.rs
+++ b/src/chain/eth/mmr_proof.rs
@@ -1,0 +1,48 @@
+use crate::{
+    chain::eth::{EthHeader, EthashProof},
+    mmr::{helper, Store},
+};
+use scale::{Decode, Encode};
+use serde::Serialize;
+
+/// Darwinia eth relay header thing
+#[derive(Decode, Encode, Default)]
+pub struct HeaderStuffs {
+    eth_header: EthHeader,
+    ethash_proof: Vec<EthashProof>,
+    mmr_root: [u8; 32],
+    mmr_proof: MMRProof,
+}
+
+/// MMR Proof Json
+#[derive(Decode, Encode, Default)]
+pub struct MMRProof {
+    /// The index of member leaf
+    member_leaf_index: u64,
+    /// The index of of last leaf
+    last_leaf_index: u64,
+    /// The mmrProof of two leaves above
+    proof: Vec<[u8; 32]>,
+}
+
+/// MMR Proof Json
+#[derive(Decode, Encode, Default, Serialize)]
+pub struct MMRProofJson {
+    /// The index of member leaf
+    pub member_leaf_index: u64,
+    /// The index of of last leaf
+    pub last_leaf_index: u64,
+    /// The mmrProof of two leaves above
+    pub proof: Vec<String>,
+}
+
+impl MMRProofJson {
+    /// Generate MMRProof
+    pub fn gen(store: &Store, member: u64, leaf: u64) -> Self {
+        Self {
+            member_leaf_index: member,
+            last_leaf_index: leaf,
+            proof: helper::gen_proof(store, member, leaf),
+        }
+    }
+}

--- a/src/chain/eth/mod.rs
+++ b/src/chain/eth/mod.rs
@@ -1,21 +1,12 @@
-//! ethereum
-use scale::{Decode, Encode};
-
+//! Ethereum types
 mod confirmation;
 mod ethash_proof;
 mod header;
-
-/// Darwinia eth relay header thing
-#[derive(Decode, Encode, Default)]
-pub struct HeaderThing {
-    eth_header: EthHeader,
-    ethash_proof: Vec<EthashProof>,
-    mmr_root: [u8; 32],
-    mmr_proof: Vec<[u8; 32]>,
-}
+mod mmr_proof;
 
 pub use self::{
     confirmation::get as confirmation,
     ethash_proof::{EthashProof, EthashProofJson},
     header::{EthHeader, EthHeaderJson, EthHeaderRPCResp},
+    mmr_proof::{HeaderStuffs, MMRProof, MMRProofJson},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! ## Usage
 //!
 //! ```sh
-//! shadow 0.2.2
+//! shadow 0.2.4
 //!
 //! USAGE:
 //!     shadow <SUBCOMMAND>

--- a/src/mmr/helper.rs
+++ b/src/mmr/helper.rs
@@ -29,17 +29,14 @@ pub fn mmr_size_to_last_leaf(mmr_size: i64) -> i64 {
 }
 
 /// Generate proof by members and last_leaf
-pub fn gen_proof(store: &Store, members: &[u64], last_leaf: u64) -> Vec<String> {
-    match MMR::<_, MergeHash, _>::new(cmmr::leaf_index_to_mmr_size(last_leaf), store).gen_proof(
-        members
-            .iter()
-            .map(|l| cmmr::leaf_index_to_pos(*l))
-            .collect(),
-    ) {
+pub fn gen_proof(store: &Store, member: u64, leaf: u64) -> Vec<String> {
+    match MMR::<_, MergeHash, _>::new(cmmr::leaf_index_to_mmr_size(leaf), store)
+        .gen_proof(vec![cmmr::leaf_index_to_pos(member)])
+    {
         Err(e) => {
             error!(
                 "Generate proof failed {:?}, last_leaf: {:?}, leaves: {:?}",
-                e, last_leaf, members,
+                e, leaf, member,
             );
             vec![]
         }

--- a/src/mmr/helper.rs
+++ b/src/mmr/helper.rs
@@ -29,14 +29,14 @@ pub fn mmr_size_to_last_leaf(mmr_size: i64) -> i64 {
 }
 
 /// Generate proof by members and last_leaf
-pub fn gen_proof(store: &Store, member: u64, leaf: u64) -> Vec<String> {
-    match MMR::<_, MergeHash, _>::new(cmmr::leaf_index_to_mmr_size(leaf), store)
+pub fn gen_proof(store: &Store, member: u64, last_leaf: u64) -> Vec<String> {
+    match MMR::<_, MergeHash, _>::new(cmmr::leaf_index_to_mmr_size(last_leaf), store)
         .gen_proof(vec![cmmr::leaf_index_to_pos(member)])
     {
         Err(e) => {
             error!(
                 "Generate proof failed {:?}, last_leaf: {:?}, leaves: {:?}",
-                e, leaf, member,
+                e, last_leaf, member,
             );
             vec![]
         }

--- a/src/mmr/runner.rs
+++ b/src/mmr/runner.rs
@@ -41,9 +41,9 @@ impl Runner {
 
         loop {
             match self.push(ptr, mmr_size).await {
-                Err(e) => {
-                    trace!("Push block to mmr_store failed: {:?}", e);
-                    trace!("MMR service restarting after 10s...");
+                Err(_e) => {
+                    // trace!("Push block to mmr_store failed: {:?}", e);
+                    // trace!("MMR service restarting after 10s...");
                     actix_rt::time::delay_for(time::Duration::from_secs(10)).await;
                 }
                 Ok(mmr_size_new) => {
@@ -54,7 +54,7 @@ impl Runner {
                             .unwrap_or(10000)
                         == 0
                     {
-                        info!("Pushed mmr {} into database", ptr);
+                        trace!("Pushed mmr {} into database", ptr);
                     }
 
                     mmr_size = mmr_size_new;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -44,19 +44,19 @@ async fn test_proposal() {
     let confirmed = ProposalReq {
         member: 0,
         target: 0,
-        leaf: 0,
+        last_leaf: 0,
     };
 
     // New relay call - Round 0
     let req_r0 = ProposalReq {
         member: confirmed.target,
         target: 3,
-        leaf: 2,
+        last_leaf: 2,
     };
 
     // Verify MMR
     let p_r0 = MerkleProof::<[u8; 32], MergeHash>::new(
-        cmmr::leaf_index_to_mmr_size(req_r0.leaf),
+        cmmr::leaf_index_to_mmr_size(req_r0.last_leaf),
         req_r0
             .mmr_proof(&shared.store)
             .into_iter()
@@ -83,12 +83,12 @@ async fn test_proposal() {
     let req_r1 = ProposalReq {
         member: 2,
         target: 2,
-        leaf: 2,
+        last_leaf: 2,
     };
 
     // Verify MMR
     let p_r1 = MerkleProof::<[u8; 32], MergeHash>::new(
-        cmmr::leaf_index_to_mmr_size(req_r1.leaf),
+        cmmr::leaf_index_to_mmr_size(req_r1.last_leaf),
         req_r1
             .mmr_proof(&shared.store)
             .into_iter()

--- a/tests/mock/mod.rs
+++ b/tests/mock/mod.rs
@@ -2,15 +2,15 @@ mod ethash_proof;
 mod ethash_proof_codec;
 mod hash;
 mod header;
-mod header_thing;
-mod mock_header_19;
+// mod header_thing;
+// mod mock_header_19;
 
 pub use ethash_proof::{DAG_NODES, PROOF};
 pub use ethash_proof_codec::ETHASH_PROOF_CODEC;
 pub use hash::HASHES;
 pub use header::HEADER;
-pub use header_thing::ETH_HEADER_THING;
-pub use mock_header_19::MOCK_HEADER_19;
+// pub use header_thing::ETH_HEADER_THING;
+// pub use mock_header_19::MOCK_HEADER_19;
 use scale::Decode;
 
 use darwinia_shadow::{

--- a/tests/scale.rs
+++ b/tests/scale.rs
@@ -2,10 +2,10 @@ mod mock;
 
 use darwinia_shadow::{
     bytes,
-    chain::eth::{EthHeader, EthashProof, HeaderThing},
+    chain::eth::{EthHeader, EthashProof},
     hex,
 };
-use mock::{ha, header, proof, ETHASH_PROOF_CODEC, ETH_HEADER_THING, HEADER, MOCK_HEADER_19};
+use mock::{ha, header, proof, ETHASH_PROOF_CODEC, HEADER};
 use scale::{Decode, Encode};
 
 /// the scale codec of hash is its hex string
@@ -44,16 +44,6 @@ fn eth_header() {
         header,
         EthHeader::decode(&mut bytes!(encoded.as_str()).as_ref()).unwrap()
     );
-}
-
-#[test]
-fn eth_header_thing() {
-    assert!(HeaderThing::decode(&mut bytes!(ETH_HEADER_THING).as_ref()).is_ok());
-}
-
-#[test]
-fn mock_header_thing() {
-    HeaderThing::decode(&mut bytes!(MOCK_HEADER_19).as_ref()).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Desc

Ref to [#81][0], follows  [#281][1], use 

```rust
pub struct MMRProof {
	pub member_leaf_index: u64,
	pub last_leaf_index: u64,
	pub proof: Vec<H256>
}
```

as the `mmr_proof` field of receipt resp.

[0]: https://github.com/darwinia-network/dj/pull/81
[1]: https://github.com/darwinia-network/darwinia-common/pull/281