### PR TITLE
Persistent epoch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darwinia-shadow"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["clearloop <udtrokia@gmail.com>"]
 edition = "2018"
 description = "The shadow service for relayers and verify workers to retrieve header data and generate proof."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ path = "src/bin/shadow.rs"
 path = "src/lib.rs"
 
 [dependencies]
+atty = "0.2.14"
 actix-web = "2.0.0"
 actix-rt = "1.0"
 blake2-rfc = "0.2.18"
@@ -41,6 +42,7 @@ libc = "0.2.71"
 log = "0.4.0"
 reqwest = { version = "0.10", features = ["json"] }
 rlp = "0.4.5"
+tar = "0.4.30"
 rocksdb = "0.15.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The shadow service for relayers and verify workers to retrieve header data and g
 ## Usage
 
 ```sh
-shadow 0.2.2
+shadow 0.2.5
 
 USAGE:
     shadow <SUBCOMMAND>

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,7 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=pkg/shadow/eth/receipt.go");
     println!("cargo:rerun-if-changed=pkg/shadow/eth/proof.go");
+    println!("cargo:rerun-if-changed=pkg/shadow/lock.go");
     println!("cargo:rerun-if-changed=pkg/shadow/ffi/mod.go");
 
     // Declare build args

--- a/pkg/shadow/eth/proof.go
+++ b/pkg/shadow/eth/proof.go
@@ -66,7 +66,7 @@ func Epoch(block uint64, config *shadow.Config) (*ethashproof.DatasetMerkleTreeC
 	epoch := block / 30000
 	cache, err := ethashproof.LoadCache(int(epoch))
 	if err != nil {
-		err = config.CreateLock(shadow.PROOF_LOCK)
+		err = config.CreateLock(shadow.PROOF_LOCK, epoch)
 		if err != nil {
 			return nil, errors.New("Create epoch lock failed")
 		}
@@ -81,7 +81,7 @@ func Epoch(block uint64, config *shadow.Config) (*ethashproof.DatasetMerkleTreeC
 			return nil, errors.New("Get ethash proof failed again, please retry")
 		}
 
-		err = config.RemoveLock(shadow.PROOF_LOCK)
+		err = config.RemoveLock(shadow.PROOF_LOCK, epoch)
 		if err != nil {
 			return nil, errors.New("Remove lock failed")
 		}

--- a/pkg/shadow/ffi/mod.go
+++ b/pkg/shadow/ffi/mod.go
@@ -16,6 +16,12 @@ func init() {
 	_ = CONFIG.Load()
 }
 
+//export Epoch
+func Epoch(block uint64) bool {
+	_, err := eth.Epoch(block, &CONFIG)
+	return err == nil
+}
+
 //export Proof
 func Proof(number uint64) *C.char {
 	header, err := eth.Header(number, CONFIG.Api)

--- a/src/api/eth/ffi.rs
+++ b/src/api/eth/ffi.rs
@@ -32,6 +32,7 @@ extern "C" {
     fn Import(path: GoString, from: libc::c_int, to: libc::c_int) -> *const c_char;
     fn Proof(input: libc::c_uint) -> *const c_char;
     fn Receipt(input: GoString) -> GoTuple;
+    fn Epoch(input: libc::c_uint) -> bool;
 }
 
 /// Proof eth header by number
@@ -41,6 +42,11 @@ pub fn proof(block: u64) -> String {
             .to_string_lossy()
             .to_string()
     }
+}
+
+/// Proof eth header by number
+pub fn epoch(block: u64) -> bool {
+    unsafe { Epoch(block as u32) }
 }
 
 /// Get receipt by tx hash

--- a/src/api/eth/mod.rs
+++ b/src/api/eth/mod.rs
@@ -7,7 +7,7 @@ mod receipt;
 
 pub use self::{
     count::handle as count,
-    ffi::import,
+    ffi::{epoch, import},
     header::handle as header,
     proposal::{handle as proposal, ProposalReq},
     receipt::handle as receipt,

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -1,0 +1,11 @@
+use crate::{result::Error, ShadowShared};
+use rocksdb::backup::{BackupEngine, BackupEngineOptions};
+use std::path::PathBuf;
+
+/// Exec export command
+pub fn exec(dist: PathBuf) -> Result<(), Error> {
+    let shared = ShadowShared::new(None);
+    let mut engine = BackupEngine::open(&BackupEngineOptions::default(), dist)?;
+    engine.create_new_backup_flush(&shared.db, true)?;
+    Ok(())
+}

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -13,7 +13,7 @@ pub fn exec(dist: Option<PathBuf>) -> Result<(), Error> {
     let tmp = env::temp_dir();
 
     // Create backup of rocksdb
-    let dir = if let Some(p) = dist { p } else { tmp.clone() };
+    let dir = if let Some(p) = dist { p } else { tmp };
     let mut rocks = dir.clone();
     rocks.push("shadow_mmr");
 
@@ -23,7 +23,7 @@ pub fn exec(dist: Option<PathBuf>) -> Result<(), Error> {
 
     // Tar backup
     if atty::is(atty::Stream::Stdout) {
-        let mut tar = dir.clone();
+        let mut tar = dir;
         tar.push("shadow_mmr.tar");
 
         let mut ar = Builder::new(File::create(tar)?);

--- a/src/cmd/export.rs
+++ b/src/cmd/export.rs
@@ -1,11 +1,39 @@
 use crate::{result::Error, ShadowShared};
 use rocksdb::backup::{BackupEngine, BackupEngineOptions};
-use std::path::PathBuf;
+use std::{
+    env,
+    fs::{self, File},
+    io::stdout,
+    path::PathBuf,
+};
+use tar::Builder;
 
 /// Exec export command
-pub fn exec(dist: PathBuf) -> Result<(), Error> {
+pub fn exec(dist: Option<PathBuf>) -> Result<(), Error> {
+    let tmp = env::temp_dir();
+
+    // Create backup of rocksdb
+    let dir = if let Some(p) = dist { p } else { tmp.clone() };
+    let mut rocks = dir.clone();
+    rocks.push("shadow_mmr");
+
     let shared = ShadowShared::new(None);
-    let mut engine = BackupEngine::open(&BackupEngineOptions::default(), dist)?;
+    let mut engine = BackupEngine::open(&BackupEngineOptions::default(), &rocks)?;
     engine.create_new_backup_flush(&shared.db, true)?;
+
+    // Tar backup
+    if atty::is(atty::Stream::Stdout) {
+        let mut tar = dir.clone();
+        tar.push("shadow_mmr.tar");
+
+        let mut ar = Builder::new(File::create(tar)?);
+        ar.append_dir_all("shadow_mmr", &rocks)?;
+    } else {
+        let mut ar = Builder::new(stdout());
+        ar.append_dir_all("shadow_mmr", &rocks)?;
+    };
+
+    // clean backup
+    fs::remove_dir_all(rocks)?;
     Ok(())
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -23,16 +23,16 @@ enum Opt {
         #[structopt(short, long)]
         verbose: bool,
     },
-    /// Imports mmr from geth
+    /// Imports mmr from shadow backup or geth
     Import {
         /// Datadir of geth
         #[structopt(short, long)]
         path: String,
         /// From Ethereum block height
-        #[structopt(short, long)]
+        #[structopt(short, long, default_value = "0")]
         from: i32,
         /// To Ethereum block height
-        #[structopt(short, long)]
+        #[structopt(short, long, default_value = "8000000")]
         to: i32,
     },
     /// Exports shadow's rocksdb

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,8 +1,10 @@
 //! `shadow` commands
 use crate::result::Error;
+use std::path::PathBuf;
 use structopt::{clap::AppSettings, StructOpt};
 
 mod count;
+mod export;
 mod import;
 mod run;
 mod trim;
@@ -33,6 +35,12 @@ enum Opt {
         #[structopt(short, long)]
         to: i32,
     },
+    /// Exports shadow's rocksdb
+    Export {
+        /// Target datadir
+        #[structopt(short, long)]
+        dist: PathBuf,
+    },
     /// Trim mmr from target leaf
     Trim {
         /// The target leaf
@@ -48,6 +56,7 @@ pub async fn exec() -> Result<(), Error> {
         Opt::Run { port, verbose } => run::exec(port, verbose).await,
         Opt::Import { path, from, to } => import::exec(path, from, to),
         Opt::Trim { leaf } => trim::exec(leaf),
+        Opt::Export { dist } => export::exec(dist),
     }?;
 
     Ok::<(), Error>(())

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -39,7 +39,7 @@ enum Opt {
     Export {
         /// Target datadir
         #[structopt(short, long)]
-        dist: PathBuf,
+        dist: Option<PathBuf>,
     },
     /// Trim mmr from target leaf
     Trim {

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -13,7 +13,7 @@ pub async fn exec(port: u16, verbose: bool) -> Result<(), Error> {
         }
     }
     env_logger::init();
-    let (mr, ar) = futures::join!(runner.start(), api::serve(port, shared));
+    let (mr, ar) = futures::join!(api::serve(port, shared), runner.start());
     mr?;
     ar?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! ## Usage
 //!
 //! ```sh
-//! shadow 0.2.4
+//! shadow 0.2.5
 //!
 //! USAGE:
 //!     shadow <SUBCOMMAND>

--- a/src/mmr/runner.rs
+++ b/src/mmr/runner.rs
@@ -1,5 +1,6 @@
 //! MMR Runner
 use crate::{
+    api::eth::epoch,
     chain::eth::EthHeaderRPCResp,
     mmr::{
         hash::{MergeHash, H256},
@@ -40,10 +41,15 @@ impl Runner {
         let mut ptr = if last_leaf == 0 { 0 } else { last_leaf + 1 };
 
         loop {
+            /// Note:
+            ///
+            /// This trigger is ungly, need better solution in the future
+            if ptr % 30000 == 0 {
+                epoch(ptr as u64);
+            }
+
             match self.push(ptr, mmr_size).await {
                 Err(_e) => {
-                    // trace!("Push block to mmr_store failed: {:?}", e);
-                    // trace!("MMR service restarting after 10s...");
                     actix_rt::time::delay_for(time::Duration::from_secs(10)).await;
                 }
                 Ok(mmr_size_new) => {

--- a/src/mmr/runner.rs
+++ b/src/mmr/runner.rs
@@ -41,9 +41,9 @@ impl Runner {
         let mut ptr = if last_leaf == 0 { 0 } else { last_leaf + 1 };
 
         loop {
-            /// Note:
-            ///
-            /// This trigger is ungly, need better solution in the future
+            // Note:
+            //
+            // This trigger is ungly, need better solution in the future
             if ptr % 30000 == 0 {
                 epoch(ptr as u64);
             }

--- a/src/mmr/runner.rs
+++ b/src/mmr/runner.rs
@@ -53,8 +53,7 @@ impl Runner {
             //
             // This trigger is ungly, need better solution in the future
             if ptr % 30000 == 0 {
-                let block = ptr.clone();
-                thread::spawn(move || Self::epoch(block as u64))
+                thread::spawn(move || Self::epoch(ptr as u64))
                     .join()
                     .unwrap_or_default();
             }


### PR DESCRIPTION
## Desc

Epoch should cover all potential blocks, call the epoch function in the Rust side.

This version triggers `epoch` every time the mmr runner(runner will reach every Ethereum block) reach epoch block(`block % 30000 == 0`).

### Data Backup

Supports `shadow export` in this version, for example:

```shell
# Tar the backup of rocksdb
$ shadow export

# Tar the backup of rocksdb and pipe the stream into gzip binary
$ shadow export | gzip
```
