### PR TITLE
Parent mmr root & implement api error response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 **/*target
 **/*Cargo.lock
 .idea
+/ffi
+/mmr
+/api

--- a/README.md
+++ b/README.md
@@ -66,6 +66,259 @@ $ cargo install darwinia-shadow
 Everytime you run `proof` in error, please delete `~/.ethashproof` and `~/.ethash` 
 and retry.
 
+## Apis
+
+### Get the total number of leaves
+
+##### REQUEST
+
+`GET /ethereum/count`
+
+##### RESPONSE
+
+```json
+{
+  "error": "INTEGER, the total number of leaves"
+}
+```
+
+```json
+{ 
+  "error": "STRING, error message"
+}
+```
+
+##### EXAMPLE
+
+```bash
+> curl https://shadow.darwinia.network/ethereum/count
+{"count":128}
+```
+
+
+
+### Get the mmr leaf by leaf index
+
+##### REQUEST
+
+`GET /ethereum/mmr_leaf/{leaf_index}`
+
+##### REQUEST PARAMS
+
+`leaf_index`: from 0
+
+##### RESPONSE
+
+```json
+{
+  "mmr_leaf": "STRING, the mmr leaf"
+}
+```
+
+```json
+{ 
+  "error": "STRING, error message"
+}
+```
+
+##### EXAMPLE
+
+```bash
+> curl https://shadow.darwinia.network/ethereum/mmr_leaf/10
+{"mmr_leaf":"0x4ff4a38b278ab49f7739d3a4ed4e12714386a9fdf72192f2e8f7da7822f10b4d"}
+```
+
+
+
+### Get the mmr root by leaf's parent index
+
+##### REQUEST
+
+`GET /ethereum/parent_mmr_root/{leaf_index}`
+
+##### REQUEST PARAMS
+
+`leaf_index`:  from 0
+
+##### RESPONSE
+
+```json
+{
+  "mmr_root": "INTEGER, the mmr root of (leaf_index-1)"
+}
+```
+
+```json
+{ 
+  "error": "STRING, error message"
+}
+```
+
+##### EXAMPLE
+
+```bash
+> curl https://shadow.darwinia.network/ethereum/parent_mmr_root/10
+{"mmr_root":"0xe28d7f650efb9cbaaca7f485d078c0f6b1104807a3a31f85fc1268b0673140ff"}
+```
+
+
+
+### Get the mmr root by leaf index
+
+##### REQUEST
+
+`GET /ethereum/mmr_root/{leaf_index}`
+
+##### REQUEST PARAMS
+
+`leaf_index`:  from 0
+
+##### RESPONSE
+
+```json
+{
+  "mmr_root": "INTEGER, the mmr root of leaf_index"
+}
+```
+
+```json
+{ 
+  "error": "STRING, error message"
+}
+```
+
+##### EXAMPLE
+
+```bash
+> curl https://shadow.darwinia.network/ethereum/mmr_root/9
+{"mmr_root":"0xe28d7f650efb9cbaaca7f485d078c0f6b1104807a3a31f85fc1268b0673140ff"}
+```
+
+
+
+### Get proofs
+
+1. get the mmr proof of `member` under the root of `last_leaf`'s mountain
+2. get the ethash of `target` block
+
+##### REQUEST
+
+`POST /ethereum/proof`
+
+##### REQUEST PARAMS
+
+```json
+{
+	"member": 2, // leaf index, just to get the mmr proof for this leaf
+	"last_leaf": 9, // mmr mountain boundary, mmr_proof_of(member, last_leaf)
+  "target": 10 // ethash of target, last_leaf == target - 1
+}
+```
+
+##### RESPONSE
+
+```json
+{
+  "ethash_proof": [
+    {
+      "dag_nodes": [ 
+        "0x5f5a713f8189...",
+        "0x0011509c9e55..."
+      ],
+      "proof": [
+        "0x4d1fe9b0c4bd1e33ca4887ed3e49f244",
+        ...
+      ]
+    },
+    ...
+  ],
+  "mmr_proof": [
+    "0x3d6122660cc824376f11ee842f83addc3525e2dd6756b9bcf0affa6aa88cf741",
+    ...
+  ]
+}
+```
+
+```json
+{ 
+  "error": "STRING, error message"
+}
+```
+
+##### EXAMPLE
+
+```bash
+> curl https://shadow.darwinia.network/ethereum/proof \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"member": 2, "target": 10, "last_leaf": 9}'
+{"ethash_proof":[...],"mmr_proof":[...]}
+```
+
+
+### Get ethereum tx receipt by tx hash
+
+##### REQUEST
+
+`GET /ethereum/receipt/{tx_hash}/{mmr_root_height}`
+
+##### REQUEST PARAMS
+
+`tx_hash`:  ethereum tx hash
+
+`mmr_root_height`: (mmr_root_height - 1) is the mmr leaf index for mountain boundary. 
+
+> mmr_root_height 似乎会产生歧义，建议改掉
+
+##### RESPONSE
+
+```json
+{
+  "header": {
+    "parent_hash": "hash of the parent block",
+    "timestamp": INTEGER, //the unix timestamp for when the block was collated
+    "number": INTEGER, // the block number
+    "author": "the address of the beneficiary to whom the mining rewards were given",
+    "transactions_root": "the root of the transaction trie of the block",
+    "uncles_hash": "SHA3 of the uncles data in the block",
+    "extra_data": "the extra data field of this block",
+    "state_root": "the root of the final state trie of the block",
+    "receipts_root": "the root of the receipts trie of the block",
+    "log_bloom": "the bloom filter for the logs of the block",
+    "gas_used": INTEGER, // the total used gas by all transactions in this block
+    "gas_limit": INTEGER, // the maximum gas allowed in this block
+    "difficulty": INTEGER, // the difficulty for this block
+    "seal": STRING ARRAY, //
+    "hash": "hash of the block"
+  },
+  "receipt_proof": {
+    "index": "0x4b",
+    "proof": "",
+    "header_hash": ""
+  },
+  "mmr_proof": {
+    "member_leaf_index": INTEGER, // just to get the mmr proof for this leaf
+    "last_leaf_index": INTEGER, // mmr mountain boundary, mmr_proof_of(member_leaf_index, last_leaf_index)
+    "proof": [...]
+  }
+}
+```
+
+```json
+{ 
+  "error": "STRING, error message"
+}
+```
+
+##### EXAMPLE
+
+```bash
+> curl https://shadow.darwinia.network/ethereum/receipt/0x9b8f30bc20809571dd2382433b28d259456cb7f03aec935f6592e1ba1f1173e1/11330897
+{"header":{...},"receipt_proof":{...},"mmr_proof":{...}}
+```
+
+
+
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -77,22 +77,14 @@ and retry.
 ##### RESPONSE
 
 ```json
-{
-  "error": "INTEGER, the total number of leaves"
-}
-```
-
-```json
-{ 
-  "error": "STRING, error message"
-}
+count number
 ```
 
 ##### EXAMPLE
 
 ```bash
 > curl https://shadow.darwinia.network/ethereum/count
-{"count":128}
+128
 ```
 
 
@@ -115,12 +107,6 @@ and retry.
 }
 ```
 
-```json
-{ 
-  "error": "STRING, error message"
-}
-```
-
 ##### EXAMPLE
 
 ```bash
@@ -130,67 +116,30 @@ and retry.
 
 
 
-### Get the mmr root by leaf's parent index
+### Get the mmr root in `block_number`
+
+the mmr root of block_number's parent as leaf index
 
 ##### REQUEST
 
-`GET /ethereum/parent_mmr_root/{leaf_index}`
+`GET /ethereum/mmr_root/{block_number}`
 
 ##### REQUEST PARAMS
 
-`leaf_index`:  from 0
+`block_number`:  from 0
 
 ##### RESPONSE
 
 ```json
 {
-  "mmr_root": "INTEGER, the mmr root of (leaf_index-1)"
-}
-```
-
-```json
-{ 
-  "error": "STRING, error message"
+  "mmr_root": "INTEGER, the mmr root of block_number's parent(block_number-1) as leaf index."
 }
 ```
 
 ##### EXAMPLE
 
 ```bash
-> curl https://shadow.darwinia.network/ethereum/parent_mmr_root/10
-{"mmr_root":"0xe28d7f650efb9cbaaca7f485d078c0f6b1104807a3a31f85fc1268b0673140ff"}
-```
-
-
-
-### Get the mmr root by leaf index
-
-##### REQUEST
-
-`GET /ethereum/mmr_root/{leaf_index}`
-
-##### REQUEST PARAMS
-
-`leaf_index`:  from 0
-
-##### RESPONSE
-
-```json
-{
-  "mmr_root": "INTEGER, the mmr root of leaf_index"
-}
-```
-
-```json
-{ 
-  "error": "STRING, error message"
-}
-```
-
-##### EXAMPLE
-
-```bash
-> curl https://shadow.darwinia.network/ethereum/mmr_root/9
+> curl https://shadow.darwinia.network/ethereum/mmr_root/10
 {"mmr_root":"0xe28d7f650efb9cbaaca7f485d078c0f6b1104807a3a31f85fc1268b0673140ff"}
 ```
 
@@ -239,12 +188,6 @@ and retry.
 }
 ```
 
-```json
-{ 
-  "error": "STRING, error message"
-}
-```
-
 ##### EXAMPLE
 
 ```bash
@@ -252,8 +195,9 @@ and retry.
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"member": 2, "target": 10, "last_leaf": 9}'
-{"ethash_proof":[...],"mmr_proof":[...]}
+{"ethash_proof":[],"mmr_proof":[]}
 ```
+
 
 
 ### Get ethereum tx receipt by tx hash
@@ -276,8 +220,8 @@ and retry.
 {
   "header": {
     "parent_hash": "hash of the parent block",
-    "timestamp": INTEGER, //the unix timestamp for when the block was collated
-    "number": INTEGER, // the block number
+    "timestamp": "INTEGER, the unix timestamp for when the block was collated",
+    "number": "INTEGER, the block number",
     "author": "the address of the beneficiary to whom the mining rewards were given",
     "transactions_root": "the root of the transaction trie of the block",
     "uncles_hash": "SHA3 of the uncles data in the block",
@@ -285,10 +229,10 @@ and retry.
     "state_root": "the root of the final state trie of the block",
     "receipts_root": "the root of the receipts trie of the block",
     "log_bloom": "the bloom filter for the logs of the block",
-    "gas_used": INTEGER, // the total used gas by all transactions in this block
-    "gas_limit": INTEGER, // the maximum gas allowed in this block
-    "difficulty": INTEGER, // the difficulty for this block
-    "seal": STRING ARRAY, //
+    "gas_used": "INTEGER, the total used gas by all transactions in this block",
+    "gas_limit": "INTEGER, the maximum gas allowed in this block",
+    "difficulty": "INTEGER, the difficulty for this block",
+    "seal": "STRING ARRAY",
     "hash": "hash of the block"
   },
   "receipt_proof": {
@@ -297,16 +241,10 @@ and retry.
     "header_hash": ""
   },
   "mmr_proof": {
-    "member_leaf_index": INTEGER, // just to get the mmr proof for this leaf
-    "last_leaf_index": INTEGER, // mmr mountain boundary, mmr_proof_of(member_leaf_index, last_leaf_index)
-    "proof": [...]
+    "member_leaf_index": "INTEGER, just to get the mmr proof for this leaf",
+    "last_leaf_index": "INTEGER, mmr mountain boundary, mmr_proof_of(member_leaf_index, last_leaf_index)",
+    "proof": []
   }
-}
-```
-
-```json
-{ 
-  "error": "STRING, error message"
 }
 ```
 
@@ -314,9 +252,8 @@ and retry.
 
 ```bash
 > curl https://shadow.darwinia.network/ethereum/receipt/0x9b8f30bc20809571dd2382433b28d259456cb7f03aec935f6592e1ba1f1173e1/11330897
-{"header":{...},"receipt_proof":{...},"mmr_proof":{...}}
+{"header":{},"receipt_proof":{},"mmr_proof":{}}
 ```
-
 
 
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ the mmr root of block_number's parent as leaf index
 
 ##### REQUEST
 
-`GET /ethereum/mmr_root/{block_number}`
+`GET /ethereum/parent_mmr_root/{block_number}`
 
 ##### REQUEST PARAMS
 
@@ -139,7 +139,7 @@ the mmr root of block_number's parent as leaf index
 ##### EXAMPLE
 
 ```bash
-> curl https://shadow.darwinia.network/ethereum/mmr_root/10
+> curl https://shadow.darwinia.network/ethereum/parent_mmr_root/10
 {"mmr_root":"0xe28d7f650efb9cbaaca7f485d078c0f6b1104807a3a31f85fc1268b0673140ff"}
 ```
 

--- a/src/api/ethereum/helper.rs
+++ b/src/api/ethereum/helper.rs
@@ -7,9 +7,10 @@ use actix_web::error;
 use cmmr::MMR;
 use primitives::{chain::ethereum::EthereumHeaderJson, rpc::RPC};
 
+/// Web result
 pub type WebResult<R> = Result<R, error::Error>;
 
-// Get mmr_root string with web response
+/// Get mmr_root string with web response
 pub fn mmr_root(block: u64, shared: &ShadowShared) -> WebResult<String> {
     let num: u64 = block.to_string().parse().unwrap_or(0);
     if num == 0 {
@@ -28,7 +29,7 @@ pub fn mmr_root(block: u64, shared: &ShadowShared) -> WebResult<String> {
     }
 }
 
-// Get header json with web response
+/// Get header json with web response
 pub async fn header(block: u64, shared: &ShadowShared) -> WebResult<EthereumHeaderJson> {
     if let Ok(h) = shared.eth.get_header_by_number(block).await {
         Ok(h.into())
@@ -40,7 +41,7 @@ pub async fn header(block: u64, shared: &ShadowShared) -> WebResult<EthereumHead
     }
 }
 
-// Get header json with web response
+/// Get header json with web response
 pub async fn header_by_hash(block: &str, shared: &ShadowShared) -> WebResult<EthereumHeaderJson> {
     if let Ok(h) = shared.eth.get_header_by_hash(block).await {
         Ok(h.into())

--- a/src/api/ethereum/helper.rs
+++ b/src/api/ethereum/helper.rs
@@ -10,8 +10,9 @@ use primitives::{chain::ethereum::EthereumHeaderJson, rpc::RPC};
 /// Web result
 pub type WebResult<R> = Result<R, error::Error>;
 
-/// Get mmr_root string with web response
-pub fn mmr_root(block: u64, shared: &ShadowShared) -> WebResult<String> {
+/// Get parent_mmr_root string with web response
+/// block's parent is leaf index
+pub fn parent_mmr_root(block: u64, shared: &ShadowShared) -> WebResult<String> {
     let num: u64 = block.to_string().parse().unwrap_or(0);
     if num == 0 {
         return Err(error::ErrorBadRequest("Requesting mmr_root of block 0"));

--- a/src/api/ethereum/helper.rs
+++ b/src/api/ethereum/helper.rs
@@ -1,0 +1,26 @@
+//! Api helpers
+use crate::{
+    mmr::{MergeHash, H256},
+    ShadowShared,
+};
+use actix_web::error;
+use cmmr::MMR;
+
+// Get mmr_root string with web response
+pub fn mmr_root(block: u64, shared: &ShadowShared) -> Result<String, error::Error> {
+    let num: u64 = block.to_string().parse().unwrap_or(0);
+    if num == 0 {
+        return Err(error::ErrorBadRequest("Requesting mmr_root of block 0"));
+    }
+
+    if let Ok(hash_bytes) =
+        MMR::<_, MergeHash, _>::new(cmmr::leaf_index_to_mmr_size(num - 1), &shared.store).get_root()
+    {
+        Ok(format!("0x{}", H256::hex(&hash_bytes)))
+    } else {
+        Err(error::ErrorInternalServerError(format!(
+            "Get mmr root of block {} failed",
+            num
+        )))
+    }
+}

--- a/src/api/ethereum/helper.rs
+++ b/src/api/ethereum/helper.rs
@@ -5,9 +5,12 @@ use crate::{
 };
 use actix_web::error;
 use cmmr::MMR;
+use primitives::{chain::ethereum::EthereumHeaderJson, rpc::RPC};
+
+pub type WebResult<R> = Result<R, error::Error>;
 
 // Get mmr_root string with web response
-pub fn mmr_root(block: u64, shared: &ShadowShared) -> Result<String, error::Error> {
+pub fn mmr_root(block: u64, shared: &ShadowShared) -> WebResult<String> {
     let num: u64 = block.to_string().parse().unwrap_or(0);
     if num == 0 {
         return Err(error::ErrorBadRequest("Requesting mmr_root of block 0"));
@@ -22,5 +25,29 @@ pub fn mmr_root(block: u64, shared: &ShadowShared) -> Result<String, error::Erro
             "Get mmr root of block {} failed",
             num
         )))
+    }
+}
+
+// Get header json with web response
+pub async fn header(block: u64, shared: &ShadowShared) -> WebResult<EthereumHeaderJson> {
+    if let Ok(h) = shared.eth.get_header_by_number(block).await {
+        Ok(h.into())
+    } else {
+        return Err(error::ErrorInternalServerError(format!(
+            "Get block header {} failed",
+            block
+        )));
+    }
+}
+
+// Get header json with web response
+pub async fn header_by_hash(block: &str, shared: &ShadowShared) -> WebResult<EthereumHeaderJson> {
+    if let Ok(h) = shared.eth.get_header_by_hash(block).await {
+        Ok(h.into())
+    } else {
+        return Err(error::ErrorInternalServerError(format!(
+            "Get block header {} failed",
+            block
+        )));
     }
 }

--- a/src/api/ethereum/mmr_leaf.rs
+++ b/src/api/ethereum/mmr_leaf.rs
@@ -1,14 +1,12 @@
 //! Ethereum MMR API
-use crate::{
-    mmr::{H256},
-    ShadowShared,
-};
-use actix_web::{web, Responder};
-use cmmr::{MMRStore};
-use primitives::bytes;
+use super::helper::WebResult;
+use crate::ShadowShared;
+use actix_web::{error, web};
+use cmmr::MMRStore;
+use primitives::{bytes, hex};
 
 /// Single MMR struct
-#[derive(Clone, Debug,Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MMRLeaf {
     /// MMR Leaf
     pub mmr_leaf: [u8; 32],
@@ -47,15 +45,24 @@ impl Into<MMRLeafJson> for MMRLeaf {
 /// ethereum::mmr_leaf(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
 /// ```
 #[allow(clippy::eval_order_dependence)]
-pub async fn handle(block: web::Path<String>, shared: web::Data<ShadowShared>) -> impl Responder {
+pub async fn handle(
+    block: web::Path<String>,
+    shared: web::Data<ShadowShared>,
+) -> WebResult<web::Json<MMRLeafJson>> {
     let num: u64 = block.to_string().parse().unwrap_or(0);
-    let leaf = H256::hex(
-        &(&shared.store)
-            .get_elem(cmmr::leaf_index_to_pos(num))
-            .unwrap().unwrap_or([0;32]),
-    );
+    let leaf = (&shared.store)
+        .get_elem(cmmr::leaf_index_to_pos(num))
+        .unwrap_or_default()
+        .unwrap_or([0; 32]);
 
-    web::Json(MMRLeafJson {
-        mmr_leaf: format!("0x{}", leaf),
-    })
+    if leaf == [0; 32] {
+        Err(error::ErrorInternalServerError(format!(
+            "Get block header {} failed",
+            block
+        )))
+    } else {
+        Ok(web::Json(MMRLeafJson {
+            mmr_leaf: format!("0x{}", hex!(&leaf)),
+        }))
+    }
 }

--- a/src/api/ethereum/mmr_leaf.rs
+++ b/src/api/ethereum/mmr_leaf.rs
@@ -51,27 +51,19 @@ pub async fn handle(
 ) -> WebResult<web::Json<MMRLeafJson>> {
     let num: u64 = block.to_string().parse().unwrap_or(0);
 
-    let leaf_result = (&shared.store)
+    (&shared.store)
         .get_elem(cmmr::leaf_index_to_pos(num))
         .and_then(|elem: Option<[u8; 32]> | {
             elem.ok_or(
-                cmmr::Error::StoreError(format!("There is no leaf of index {} found in store", num))
+                cmmr::Error::StoreError(format!("No leaf of index {} found in store", num))
             )
         })
-        .map(|leaf| format!("0x{}", hex!(&leaf)));
-
-    match leaf_result {
-        Ok(leaf) => {
-            Ok(web::Json(MMRLeafJson {
-                mmr_leaf: leaf,
-            }))
-        },
-        Err(err) => {
-            Err(error::ErrorInternalServerError(format!(
-                "Get mmr leaf of {} failed, caused by {}",
+        .map(|leaf| format!("0x{}", hex!(&leaf)))
+        .map(|mmr_leaf| web::Json(MMRLeafJson { mmr_leaf }))
+        .map_err(|err| {
+            error::ErrorInternalServerError(format!(
+                "Get mmr leaf of {} failed, caused by: {}",
                 block, err.to_string()
-            )))
-        }
-    }
-
+            ))
+        })
 }

--- a/src/api/ethereum/mmr_leaf.rs
+++ b/src/api/ethereum/mmr_leaf.rs
@@ -53,7 +53,11 @@ pub async fn handle(
 
     let leaf_result = (&shared.store)
         .get_elem(cmmr::leaf_index_to_pos(num))
-        .map(|elem| elem.unwrap_or([0; 32]))
+        .and_then(|elem: Option<[u8; 32]> | {
+            elem.ok_or(
+                cmmr::Error::StoreError(format!("There is no leaf of index {} found in store", num))
+            )
+        })
         .map(|leaf| format!("0x{}", hex!(&leaf)));
 
     match leaf_result {

--- a/src/api/ethereum/mmr_root.rs
+++ b/src/api/ethereum/mmr_root.rs
@@ -20,7 +20,7 @@ use primitives::chain::ethereum::MMRRootJson;
 pub async fn handle(block: web::Path<String>, shared: web::Data<ShadowShared>) -> impl Responder {
     let num: u64 = block.to_string().parse().unwrap_or(0);
     if num == 0 {
-        return Err(error::ErrorBadRequest("Requesting mmr of block 0"));
+        return Err(error::ErrorBadRequest("Requesting mmr_root of block 0"));
     }
 
     if let Ok(hash_bytes) =

--- a/src/api/ethereum/mmr_root.rs
+++ b/src/api/ethereum/mmr_root.rs
@@ -9,8 +9,8 @@ use primitives::chain::ethereum::MMRRootJson;
 /// use actix_web::web;
 /// use darwinia_shadow::{api::ethereum, ShadowShared};
 ///
-/// // GET `/ethereum/mmr_root/19`
-/// ethereum::mmr_root(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
+/// // GET `/ethereum/parent_mmr_root/19`
+/// ethereum::parent_mmr_root(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
 /// ```
 pub async fn handle(
     block: web::Path<String>,
@@ -18,6 +18,6 @@ pub async fn handle(
 ) -> super::helper::WebResult<web::Json<MMRRootJson>> {
     let num: u64 = block.to_string().parse().unwrap_or(0);
     Ok(web::Json(MMRRootJson {
-        mmr_root: super::helper::mmr_root(num, &shared)?,
+        mmr_root: super::helper::parent_mmr_root(num, &shared)?,
     }))
 }

--- a/src/api/ethereum/mmr_root.rs
+++ b/src/api/ethereum/mmr_root.rs
@@ -3,7 +3,7 @@ use crate::{
     mmr::{MergeHash, H256},
     ShadowShared,
 };
-use actix_web::{web, Responder};
+use actix_web::{error, web, Responder};
 use cmmr::MMR;
 use primitives::chain::ethereum::MMRRootJson;
 
@@ -19,17 +19,20 @@ use primitives::chain::ethereum::MMRRootJson;
 #[allow(clippy::eval_order_dependence)]
 pub async fn handle(block: web::Path<String>, shared: web::Data<ShadowShared>) -> impl Responder {
     let num: u64 = block.to_string().parse().unwrap_or(0);
-    let root = if num == 0 {
-        "0000000000000000000000000000000000000000000000000000000000000000".to_string()
-    } else {
-        H256::hex(
-            &MMR::<_, MergeHash, _>::new(cmmr::leaf_index_to_mmr_size(num - 1), &shared.store)
-                .get_root()
-                .unwrap_or_default(),
-        )
-    };
+    if num == 0 {
+        return Err(error::ErrorBadRequest("Requesting mmr of block 0"));
+    }
 
-    web::Json(MMRRootJson {
-        mmr_root: format!("0x{}", root),
-    })
+    if let Ok(hash_bytes) =
+        MMR::<_, MergeHash, _>::new(cmmr::leaf_index_to_mmr_size(num - 1), &shared.store).get_root()
+    {
+        Ok(web::Json(MMRRootJson {
+            mmr_root: format!("0x{}", H256::hex(&hash_bytes)),
+        }))
+    } else {
+        Err(error::ErrorInternalServerError(format!(
+            "Get mmr root of block {} failed",
+            num
+        )))
+    }
 }

--- a/src/api/ethereum/mmr_root.rs
+++ b/src/api/ethereum/mmr_root.rs
@@ -10,7 +10,7 @@ use primitives::chain::ethereum::MMRRootJson;
 /// use darwinia_shadow::{api::ethereum, ShadowShared};
 ///
 /// // GET `/ethereum/parent_mmr_root/19`
-/// ethereum::parent_mmr_root(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
+/// ethereum::mmr_root(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
 /// ```
 pub async fn handle(
     block: web::Path<String>,

--- a/src/api/ethereum/mmr_root.rs
+++ b/src/api/ethereum/mmr_root.rs
@@ -1,6 +1,6 @@
 //! Ethereum MMR API
 use crate::ShadowShared;
-use actix_web::{error::Error, web};
+use actix_web::web;
 use primitives::chain::ethereum::MMRRootJson;
 
 /// Get target mmr
@@ -12,11 +12,10 @@ use primitives::chain::ethereum::MMRRootJson;
 /// // GET `/ethereum/mmr_root/19`
 /// ethereum::mmr_root(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
 /// ```
-#[allow(clippy::eval_order_dependence)]
 pub async fn handle(
     block: web::Path<String>,
     shared: web::Data<ShadowShared>,
-) -> Result<web::Json<MMRRootJson>, Error> {
+) -> super::helper::WebResult<web::Json<MMRRootJson>> {
     let num: u64 = block.to_string().parse().unwrap_or(0);
     Ok(web::Json(MMRRootJson {
         mmr_root: super::helper::mmr_root(num, &shared)?,

--- a/src/api/ethereum/mmr_root.rs
+++ b/src/api/ethereum/mmr_root.rs
@@ -1,10 +1,6 @@
 //! Ethereum MMR API
-use crate::{
-    mmr::{MergeHash, H256},
-    ShadowShared,
-};
-use actix_web::{error, web, Responder};
-use cmmr::MMR;
+use crate::ShadowShared;
+use actix_web::{error::Error, web};
 use primitives::chain::ethereum::MMRRootJson;
 
 /// Get target mmr
@@ -17,22 +13,12 @@ use primitives::chain::ethereum::MMRRootJson;
 /// ethereum::mmr_root(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
 /// ```
 #[allow(clippy::eval_order_dependence)]
-pub async fn handle(block: web::Path<String>, shared: web::Data<ShadowShared>) -> impl Responder {
+pub async fn handle(
+    block: web::Path<String>,
+    shared: web::Data<ShadowShared>,
+) -> Result<web::Json<MMRRootJson>, Error> {
     let num: u64 = block.to_string().parse().unwrap_or(0);
-    if num == 0 {
-        return Err(error::ErrorBadRequest("Requesting mmr_root of block 0"));
-    }
-
-    if let Ok(hash_bytes) =
-        MMR::<_, MergeHash, _>::new(cmmr::leaf_index_to_mmr_size(num - 1), &shared.store).get_root()
-    {
-        Ok(web::Json(MMRRootJson {
-            mmr_root: format!("0x{}", H256::hex(&hash_bytes)),
-        }))
-    } else {
-        Err(error::ErrorInternalServerError(format!(
-            "Get mmr root of block {} failed",
-            num
-        )))
-    }
+    Ok(web::Json(MMRRootJson {
+        mmr_root: super::helper::mmr_root(num, &shared)?,
+    }))
 }

--- a/src/api/ethereum/mod.rs
+++ b/src/api/ethereum/mod.rs
@@ -1,8 +1,9 @@
 //! Ethereum API
 mod count;
 mod ffi;
-mod mmr_root;
+mod helper;
 mod mmr_leaf;
+mod mmr_root;
 mod parcel;
 mod proof;
 mod receipt;
@@ -10,8 +11,8 @@ mod receipt;
 pub use self::{
     count::handle as count,
     ffi::{epoch, import},
-    mmr_root::handle as mmr_root,
     mmr_leaf::handle as mmr_leaf,
+    mmr_root::handle as mmr_root,
     parcel::handle as parcel,
     proof::{handle as proof, ProposalReq},
     receipt::handle as receipt,

--- a/src/api/ethereum/mod.rs
+++ b/src/api/ethereum/mod.rs
@@ -3,7 +3,7 @@ mod count;
 mod ffi;
 pub mod helper;
 mod mmr_leaf;
-mod mmr_root;
+mod parent_mmr_root;
 mod parcel;
 mod proof;
 mod receipt;
@@ -12,7 +12,7 @@ pub use self::{
     count::handle as count,
     ffi::{epoch, import},
     mmr_leaf::handle as mmr_leaf,
-    mmr_root::handle as mmr_root,
+    parent_mmr_root::handle as parent_mmr_root,
     parcel::handle as parcel,
     proof::{handle as proof, ProposalReq},
     receipt::handle as receipt,

--- a/src/api/ethereum/mod.rs
+++ b/src/api/ethereum/mod.rs
@@ -1,7 +1,7 @@
 //! Ethereum API
 mod count;
 mod ffi;
-mod helper;
+pub mod helper;
 mod mmr_leaf;
 mod mmr_root;
 mod parcel;

--- a/src/api/ethereum/parcel.rs
+++ b/src/api/ethereum/parcel.rs
@@ -21,6 +21,6 @@ pub async fn handle(
     // Gen response
     Ok(web::Json(EthereumRelayHeaderParcelJson {
         header: super::helper::header(num, &shared).await?,
-        mmr_root: super::helper::mmr_root(num, &shared)?,
+        mmr_root: super::helper::parent_mmr_root(num, &shared)?,
     }))
 }

--- a/src/api/ethereum/parcel.rs
+++ b/src/api/ethereum/parcel.rs
@@ -1,13 +1,6 @@
-use crate::{
-    mmr::{MergeHash, H256},
-    ShadowShared,
-};
-use actix_web::{error, web, Responder};
-use cmmr::MMR;
-use primitives::{
-    chain::ethereum::{EthereumHeader, EthereumRelayHeaderParcelJson},
-    rpc::RPC,
-};
+use crate::ShadowShared;
+use actix_web::web;
+use primitives::chain::ethereum::EthereumRelayHeaderParcelJson;
 
 /// Proof target header
 ///
@@ -19,34 +12,15 @@ use primitives::{
 /// ethereum::parcel(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
 /// ```
 #[allow(clippy::eval_order_dependence)]
-pub async fn handle(block: web::Path<String>, shared: web::Data<ShadowShared>) -> impl Responder {
-    let header: EthereumHeader;
+pub async fn handle(
+    block: web::Path<String>,
+    shared: web::Data<ShadowShared>,
+) -> super::helper::WebResult<web::Json<EthereumRelayHeaderParcelJson>> {
     let num: u64 = block.to_string().parse().unwrap_or(0);
-    if num == 0 {
-        return Err(error::ErrorBadRequest("Requesting mmr of block -1"));
-    }
-
-    if let Ok(h) = shared.eth.get_header_by_number(num).await {
-        header = h;
-    } else {
-        return Err(error::ErrorInternalServerError(format!(
-            "Get block header {} failed",
-            num
-        )));
-    }
 
     // Gen response
-    if let Ok(hash_bytes) =
-        MMR::<_, MergeHash, _>::new(cmmr::leaf_index_to_mmr_size(num - 1), &shared.store).get_root()
-    {
-        Ok(web::Json(EthereumRelayHeaderParcelJson {
-            header: header.into(),
-            mmr_root: format!("0x{}", H256::hex(&hash_bytes)),
-        }))
-    } else {
-        Err(error::ErrorInternalServerError(format!(
-            "Get mmr root of block {} failed",
-            num
-        )))
-    }
+    Ok(web::Json(EthereumRelayHeaderParcelJson {
+        header: super::helper::header(num, &shared).await?,
+        mmr_root: super::helper::mmr_root(num, &shared)?,
+    }))
 }

--- a/src/api/ethereum/parent_mmr_root.rs
+++ b/src/api/ethereum/parent_mmr_root.rs
@@ -10,7 +10,7 @@ use primitives::chain::ethereum::MMRRootJson;
 /// use darwinia_shadow::{api::ethereum, ShadowShared};
 ///
 /// // GET `/ethereum/parent_mmr_root/19`
-/// ethereum::mmr_root(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
+/// ethereum::parent_mmr_root(web::Path::from("19".to_string()), web::Data::new(ShadowShared::new(None)));
 /// ```
 pub async fn handle(
     block: web::Path<String>,

--- a/src/api/ethereum/proof.rs
+++ b/src/api/ethereum/proof.rs
@@ -78,7 +78,7 @@ pub async fn handle(
     let proposal = req.0;
 
     proposal.gen(share).await
-        .map(|json| web::Json(json))
+        .map(web::Json)
         .map_err(|err| {
             error::ErrorInternalServerError(format!(
                 "Get proof of (member: {}, target: {}, last_leaf: {}) failed, caused by {}",

--- a/src/api/ethereum/proof.rs
+++ b/src/api/ethereum/proof.rs
@@ -1,12 +1,12 @@
+use super::helper::WebResult;
 use crate::{
     api::ShadowShared,
-    mmr::{helper, MergeHash, Store, H256},
+    mmr::{helper as mmr_helper, Store},
 };
-use actix_web::{web, Responder};
-use cmmr::MMR;
+use actix_web::{error, web};
 use primitives::{
     bytes,
-    chain::ethereum::{EthashProof, EthashProofJson, EthereumHeaderJson, EthereumRelayProofsJson},
+    chain::ethereum::{EthashProof, EthashProofJson, EthereumRelayProofsJson},
 };
 use scale::{Decode, Encode};
 
@@ -23,31 +23,20 @@ pub struct ProposalReq {
 
 impl ProposalReq {
     /// Get `EtHashProof`
-    fn ethash_proof(&self, api: &str) -> Vec<EthashProofJson> {
+    fn ethash_proof(&self, api: &str) -> WebResult<Vec<EthashProofJson>> {
         let proof = super::ffi::proof(api, self.target);
-        <Vec<EthashProof>>::decode(&mut bytes!(proof.as_str()).as_ref())
-            .unwrap_or_default()
-            .iter()
-            .map(|p| Into::<EthashProofJson>::into(p.clone()))
-            .collect()
-    }
-
-    /// Get mmr root
-    pub fn mmr_root(&self, store: &Store) -> String {
-        if self.target < 1 {
-            "0x0000000000000000000000000000000000000000000000000000000000000000".into()
+        if let Ok(ethash_proof_vector) =
+            <Vec<EthashProof>>::decode(&mut bytes!(proof.as_str()).as_ref())
+        {
+            Ok(ethash_proof_vector
+                .iter()
+                .map(|p| Into::<EthashProofJson>::into(p.clone()))
+                .collect())
         } else {
-            format!(
-                "0x{}",
-                H256::hex(
-                    &MMR::<_, MergeHash, _>::new(
-                        cmmr::leaf_index_to_mmr_size(self.target - 1),
-                        store
-                    )
-                    .get_root()
-                    .unwrap_or_default()
-                )
-            )
+            Err(error::ErrorInternalServerError(format!(
+                "Get ethash proof of block {} failed",
+                self.target
+            )))
         }
     }
 
@@ -57,25 +46,16 @@ impl ProposalReq {
             return vec![];
         }
 
-        helper::gen_proof(store, self.member, self.last_leaf)
+        mmr_helper::gen_proof(store, self.member, self.last_leaf)
     }
 
     /// Generate response
-    pub async fn gen(&self, shared: web::Data<ShadowShared>) -> EthereumRelayProofsJson {
-        EthereumRelayProofsJson {
-            ethash_proof: self.ethash_proof(shared.eth.rpc()),
+    pub async fn gen(&self, shared: web::Data<ShadowShared>) -> WebResult<EthereumRelayProofsJson> {
+        Ok(EthereumRelayProofsJson {
+            ethash_proof: self.ethash_proof(shared.eth.rpc())?,
             mmr_proof: self.mmr_proof(&shared.store),
-        }
+        })
     }
-}
-
-/// Proposal Headers
-#[derive(Serialize, Encode)]
-pub struct ProposalHeader {
-    header: EthereumHeaderJson,
-    ethash_proof: Vec<EthashProofJson>,
-    mmr_root: String,
-    mmr_proof: Vec<String>,
 }
 
 /// Proposal Handler
@@ -91,6 +71,9 @@ pub struct ProposalHeader {
 ///     last_leaf: 18
 /// }), web::Data::new(ShadowShared::new(None)));
 /// ```
-pub async fn handle(req: web::Json<ProposalReq>, share: web::Data<ShadowShared>) -> impl Responder {
-    web::Json(req.0.gen(share).await)
+pub async fn handle(
+    req: web::Json<ProposalReq>,
+    share: web::Data<ShadowShared>,
+) -> WebResult<web::Json<EthereumRelayProofsJson>> {
+    Ok(web::Json(req.0.gen(share).await?))
 }

--- a/src/api/ethereum/proof.rs
+++ b/src/api/ethereum/proof.rs
@@ -75,5 +75,15 @@ pub async fn handle(
     req: web::Json<ProposalReq>,
     share: web::Data<ShadowShared>,
 ) -> WebResult<web::Json<EthereumRelayProofsJson>> {
-    Ok(web::Json(req.0.gen(share).await?))
+    let proposal = req.0;
+
+    proposal.gen(share).await
+        .map(|json| web::Json(json))
+        .map_err(|err| {
+            error::ErrorInternalServerError(format!(
+                "Get proof of (member: {}, target: {}, last_leaf: {}) failed, caused by {}",
+                proposal.member,  proposal.target, proposal.last_leaf,
+                err.to_string()
+            ))
+        })
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,7 +16,7 @@ pub async fn serve(port: u16, shared: ShadowShared) -> std::io::Result<()> {
             .service(web::resource("/ethereum/count").route(web::get().to(ethereum::count)))
             .service(
                 web::resource("/ethereum/parent_mmr_root/{block}")
-                    .route(web::get().to(ethereum::mmr_root)),
+                    .route(web::get().to(ethereum::parent_mmr_root)),
             )
             .service(
                 web::resource("/ethereum/mmr_leaf/{block}")

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,7 +15,7 @@ pub async fn serve(port: u16, shared: ShadowShared) -> std::io::Result<()> {
             .service(web::resource("/version").to(root::version))
             .service(web::resource("/ethereum/count").route(web::get().to(ethereum::count)))
             .service(
-                web::resource("/ethereum/mmr_root/{block}")
+                web::resource("/ethereum/parent_mmr_root/{block}")
                     .route(web::get().to(ethereum::mmr_root)),
             )
             .service(

--- a/src/mmr/store.rs
+++ b/src/mmr/store.rs
@@ -23,11 +23,14 @@ where
     H: H256 + AsRef<[u8]>,
 {
     fn get_elem(&self, pos: u64) -> MMRResult<Option<H>> {
-        if let Ok(Some(elem)) = self.db.get(pos.to_le_bytes()) {
-            Ok(Some(H::from_bytes(&elem)))
-        } else {
-            Ok(None)
-        }
+        self.db
+            .get(pos.to_le_bytes())
+            .map_err(|err| {
+                cmmr::Error::StoreError(err.to_string())
+            })
+            .map(|elem| {
+                elem.map(|e| H::from_bytes(&e))
+            })
     }
 
     fn append(&mut self, pos: u64, elems: Vec<H>) -> MMRResult<()> {

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,4 +1,5 @@
 //! MMR Errors
+use actix_web::Error as ActixWeb;
 use cmmr::Error as MMR;
 use primitives::result::Error as Primitive;
 use reqwest::Error as Reqwest;
@@ -50,7 +51,7 @@ macro_rules! error {
     };
 }
 
-error! {Io, MMR, Reqwest, SerdeJson, Rocksdb, Shadow, Primitive}
+error! {Io, MMR, Reqwest, SerdeJson, Rocksdb, Shadow, Primitive, ActixWeb}
 
 /// Sup Result
 pub type Result<T> = StdResult<T, Error>;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -68,7 +68,7 @@ async fn test_proposal() {
     // Should pass verification
     assert!(p_r0
         .verify(
-            H256::from(&helper::mmr_root(req_r0.target, &shared).unwrap()),
+            H256::from(&helper::parent_mmr_root(req_r0.target, &shared).unwrap()),
             vec![(
                 cmmr::leaf_index_to_pos(req_r0.member),
                 rpc.get_header_by_number(req_r0.member)
@@ -102,7 +102,7 @@ async fn test_proposal() {
     // The the round 0's mmr_root to verify round 1's hash
     assert!(p_r1
         .verify(
-            H256::from(&helper::mmr_root(req_r0.target, &shared).unwrap()),
+            H256::from(&helper::parent_mmr_root(req_r0.target, &shared).unwrap()),
             vec![(
                 cmmr::leaf_index_to_pos(req_r1.member),
                 rpc.get_header_by_number(req_r1.member)

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,7 +1,7 @@
 use cmmr::MerkleProof;
 use darwinia_shadow::{
-    api::ethereum::ProposalReq,
-    mmr::{helper, MergeHash, Runner, H256},
+    api::ethereum::{helper, ProposalReq},
+    mmr::{helper as mmr_helper, MergeHash, Runner, H256},
     result::Error,
     ShadowShared,
 };
@@ -11,7 +11,7 @@ use rocksdb::{IteratorMode, DB};
 async fn stops_at(db: &DB, runner: &mut Runner, count: i64) -> Result<(), Error> {
     let mut mmr_size = db.iterator(IteratorMode::Start).count() as u64;
     let mut ptr = {
-        let last_leaf = helper::mmr_size_to_last_leaf(mmr_size as i64);
+        let last_leaf = mmr_helper::mmr_size_to_last_leaf(mmr_size as i64);
         if last_leaf == 0 {
             0
         } else {
@@ -36,7 +36,7 @@ async fn stops_at(db: &DB, runner: &mut Runner, count: i64) -> Result<(), Error>
 async fn test_proposal() {
     let shared = ShadowShared::new(None);
     let mut runner = Runner::from(shared.clone());
-    let rpc = shared.eth;
+    let rpc = &shared.eth;
 
     // Gen mmrs
     assert!(stops_at(&shared.db, &mut runner, 30).await.is_ok());
@@ -68,7 +68,7 @@ async fn test_proposal() {
     // Should pass verification
     assert!(p_r0
         .verify(
-            H256::from(&req_r0.mmr_root(&shared.store)),
+            H256::from(&helper::mmr_root(req_r0.target, &shared).unwrap()),
             vec![(
                 cmmr::leaf_index_to_pos(req_r0.member),
                 rpc.get_header_by_number(req_r0.member)
@@ -102,7 +102,7 @@ async fn test_proposal() {
     // The the round 0's mmr_root to verify round 1's hash
     assert!(p_r1
         .verify(
-            H256::from(&req_r0.mmr_root(&shared.store)),
+            H256::from(&helper::mmr_root(req_r0.target, &shared).unwrap()),
             vec![(
                 cmmr::leaf_index_to_pos(req_r1.member),
                 rpc.get_header_by_number(req_r1.member)


### PR DESCRIPTION
companion of [bridger#95](https://github.com/darwinia-network/bridger/pull/95)

1. Replace the default response with error messages
2. Api mmr_root changed to parent_mmr_root